### PR TITLE
Fix ONNX import schema getter bug

### DIFF
--- a/src/onnx-model.js
+++ b/src/onnx-model.js
@@ -712,7 +712,7 @@ class OnnxOperatorMetadata {
             for (var i = 0; i < domainKeys.length; i++) {
                 var domain = domainKeys[i];
                 var versionMap = domainMap[domain];
-                var importVersion = imports[domain];
+                var importVersion = Math.max.apply(Math, Object.keys(versionMap).map(Number).filter(x => x <= imports[domain]));
                 schema = versionMap[importVersion];
                 if (!schema) {
                     var version = -1;


### PR DESCRIPTION
The getter has bug.
It can not get the latest version smaller than or equal to current opset.