### PR TITLE
Add filename parameter to requests with url

### DIFF
--- a/src/view-browser.js
+++ b/src/view-browser.js
@@ -24,7 +24,8 @@ class BrowserHost {
 
         var urlParam = this._getQueryParameter('url');
         if (urlParam && urlParam.length > 0) {
-            this._openModel(urlParam, urlParam.split('/').pop());
+            var filename = this._getQueryParameter('filename');
+            this._openModel(urlParam, filename || urlParam.split('/').pop());
             return;
         }
 


### PR DESCRIPTION
This PR solves the following problem:

* I want to embed Netron in another Node webapp
* I want to control the model displayed inside Netron. I can do this by giving Netron an `url` parameter
* However, I want Netron to show local content (picked by the user with an `input` type='file' form). Since the Node app is sandboxed, I can't pass the file path directly in the URL (using a `file://` protocol); instead, I'm using [`URL.createObjectURL`](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL) to create a temporary URL that references the file, and passing it to Netron
* The URL created by `URL.createObjectURL` doesn't have a file extension, and thus Netron's model format matching (in view.js:`loadBuffer`) fails

With this change, a request with a `url` parameter can also provide a `filename` parameter to specify the file format (e.g. `onnx`).