### PR TITLE
Python: Fix `netron.main()` and `netron` command without arguments

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -198,7 +198,6 @@ def serve(file, data, verbose=False, browse=False, port=8080, host='localhost'):
         host (string, optional): Host to serve. Default: localhost
     '''
     global thread_list
-    assert type(file) != None
     if not data and not os.path.exists(file):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), file)
     stop(port, host)

--- a/src/server.py
+++ b/src/server.py
@@ -198,7 +198,7 @@ def serve(file, data, verbose=False, browse=False, port=8080, host='localhost'):
         host (string, optional): Host to serve. Default: localhost
     '''
     global thread_list
-    if not data and not os.path.exists(file):
+    if not data and file and not os.path.exists(file):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), file)
     stop(port, host)
     thread = HTTPServerThread(data, file, verbose, browse, port, host)


### PR DESCRIPTION
This PR solves the problem that `netron.main()` returns `TypeError: stat: path
should be string, bytes, os.PathLike or integer, not NoneType`. This error has been occurs since the commit ed1846e1372cc5911b6ab4a9ebe620a52911150e.

Also, you added an assert statement in [this line](
https://github.com/lutzroeder/netron/commit/ed1846e1372cc5911b6ab4a9ebe620a52911150e#diff-94ab7c76892f0032ee9ad040e3e8f207R201), but I deleted it. It won’t become `False` because `type(file)` returns NoneType not `None` if `file` is `None`, and in that case, Netron shows the file picker screen. Therefore, I suppose that it is not needed.

If I missed something, please tell me that. Thanks.

I tested on Python 2.7 and 3.6.