### PR TITLE
Fix ONNX denotation for Image type tensors

### DIFF
--- a/src/onnx.js
+++ b/src/onnx.js
@@ -250,6 +250,7 @@ onnx.Graph = class {
         this._inputs = [];
         this._outputs = [];
         this._operators = {};
+        this._imageFormat = imageFormat;
 
         if (graph) {
             this._name = graph.name || null;


### PR DESCRIPTION
Meta information for denotated image tensor is not displayed correctly because `this._imageFormat` is undefined for `onnx.Graph` class.   