### PR TITLE
Added Gaussian_yolo layer

### DIFF
--- a/src/darknet.js
+++ b/src/darknet.js
@@ -411,37 +411,6 @@ darknet.Graph = class {
                 params.inputs = layer.outputs;
             }
             params.arguments = section.outputs;
-
-            const batch_normalize = option_find_int(section.options, 'batch_normalize', 0);
-            if (batch_normalize) {
-                let size = -1;
-                switch (section.type) {
-                    case 'convolutional': {
-                        size = option_find_int(options, 'filters', 1);
-                        break;
-                    }
-                    case 'crnn':
-                    case 'gru':
-                    case 'rnn':
-                    case 'lstm':
-                    case 'connected': {
-                        size = option_find_int(options, 'output', 1);
-                        break;
-                    }
-                }
-                if (size < 0) {
-                    throw new darknet.Error("Invalid batch_normalize size for '" + section.type + "'.");
-                }
-                let chain = {};
-                chain.type = 'batch_normalize';
-                chain.tensors = [
-                    { name: 'scale', shape: [ size ] },
-                    { name: 'mean', shape: [ size ] },
-                    { name: 'variance', shape: [ size ] }
-                ];
-                section.chain = section.chain || [];
-                section.chain.push(chain);
-            }
     
             const defaultActivation = section.type === 'shortcut' ? 'linear' : 'logistic';
             const activation = option_find_str(section.options, 'activation', defaultActivation);

--- a/src/darknet.js
+++ b/src/darknet.js
@@ -311,6 +311,18 @@ darknet.Graph = class {
                         section.outputs[0].type = new darknet.TensorType('float32', new darknet.TensorShape([ layer.out_w, layer.out_h, layer.out_c ]));
                         break;
                     }
+                    case 'Gaussian_yolo': {
+                        const w = params.w;
+                        const h = params.h;
+                        const classes = option_find_int(options, 'classes', 20);
+                        const n = option_find_int(options, 'num', 1);
+                        layer.out_h = h;
+                        layer.out_w = w;
+                        layer.out_c = n * (classes + 8 + 1);
+                        layer.outputs = layer.out_h * layer.out_w * layer.out_c;
+                        section.outputs[0].type = new darknet.TensorType('float32', new darknet.TensorShape([ layer.out_w, layer.out_h, layer.out_c ]));
+                        break;
+                    }
                     case 'region': {
                         const coords = option_find_int(options, 'coords', 4);
                         const classes = option_find_int(options, 'classes', 20);


### PR DESCRIPTION
I noticed that it did not work by looking at [https://github.com/AlexeyAB/darknet/blob/master/cfg/Gaussian_yolov3_BDD.cfg](url)

also if you could add the stride_x and stride_y, the options permit to scale only in the x/y axis, it's implemented that way:
`if (stride_x < 1 || stride_y < 1) {`
`        stride = option_find_int(options, "stride", 1);`
`        if (stride_x < 1) stride_x = stride;`
`        if (stride_y < 1) stride_y = stride;`
`    }`
`    else {`
`        stride = option_find_int_quiet(options, "stride", 1);`
`    }`

so that it's only active when stride_x or stride_y is set