### PR TITLE
Force dark mode using the electron config file entry

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -92,6 +92,9 @@ class Application {
         if (!this._configuration.has('userId')) {
             this._configuration.set('userId', require('uuid').v4());
         }
+        if (this._configuration.get('forceDarkMode'))  {
+            electron.nativeTheme.themeSource = 'dark';
+        }
         global.userId = this._configuration.get('userId');
         if (this._openFileQueue) {
             let openFileQueue = this._openFileQueue;


### PR DESCRIPTION
I'm on Ubuntu 18.04 and for some reason the app ignores the system theme setting.

![dark_mode](https://user-images.githubusercontent.com/22572387/72684657-da6fc780-3ae2-11ea-9260-6f961210ef5f.png)
![debugger](https://user-images.githubusercontent.com/22572387/72684668-e196d580-3ae2-11ea-88ee-f0a29706745c.png)

With this PR I'd like to propose a way to force the dark mode and ignore the system settings (which is what electron uses by default to determine which color mode should be used).

To acchieve it, I've editted the `configuration.json` file (located in `~/.config/Electron` in my case) and added an entry: `"forceDarkMode": true`. This value is then used to switch the `electron.nativeTheme.themeSource` property which controls the color scheme of the app https://electronjs.org/docs/api/native-theme#properties