### PR TITLE
[OpenVino] Fix issue when Sigmoid activation is not shown

### DIFF
--- a/src/openvino-metadata.json
+++ b/src/openvino-metadata.json
@@ -356,7 +356,7 @@
     "schema": {
       "attributes": [
         {
-          "default": "sigmoid",
+          "default": "",
           "description": " *type* represents particular activation function. For example, *type* equal *sigmoid* means that neurons of this layer have a sigmoid activation function.",
           "name": "type",
           "option": "required"


### PR DESCRIPTION
Even when "Show attributes" option was enabled sigmoid activation type wasn't show up.

Possible fix for https://github.com/lutzroeder/netron/issues/418