### PR TITLE
size and offset in openvino blobs to numbers

### DIFF
--- a/src/openvino.js
+++ b/src/openvino.js
@@ -347,7 +347,7 @@ openvino.Graph = class {
                     }
                     const shape = data['shape'] ? data['shape'].split(',').map((dim) => parseInt(dim.trim(), 10)) : null;
                     layer.data = [];
-                    layer.blobs.push({ name: 'custom', precision: precision, offset: data['offset'], size: data['size'], shape: shape });
+                    layer.blobs.push({ name: 'custom', precision: precision, offset: parseInt(data['offset'], 10), size: parseInt(data['size'], 10), shape: shape });
                 }
             }
             if (layer.type === 'Const' && layer.blobs.length === 1 && !layer.blobs[0].shape &&


### PR DESCRIPTION
This is observed in IRv10, so it can probably be not supported.

`typeof(offset) == "string"` and `typeof(size) == "string".`
As a result, we get that "string" + "string" is compared with "number" 
`(offset + size) <= bin.length`
and the result might not be the one expected.

For my model it ended up loading weights only for the first few layers.
