### PR TITLE
check if openvino precision is null

### DIFF
--- a/src/openvino.js
+++ b/src/openvino.js
@@ -877,7 +877,10 @@ openvino.Tensor = class {
 openvino.TensorType = class {
 
     constructor(precision, shape) {
-        switch (precision.toLowerCase()) {
+        if (precision != null) {
+            precision = precision.toLowerCase()
+        }
+        switch (precision) {
             case 'f16':  this._dataType = 'float16'; break;
             case 'fp16': this._dataType = 'float16'; break;
             case 'f32':  this._dataType = 'float32'; break;


### PR DESCRIPTION
The error solved is 
Error loading OpenVINO model. Cannot read property 'toLowerCase' of null in 'netname.xml'.
when trying to load xml file.

It is observed with IRv10.
precision null is handled in switch, so it's probably ok that it is passed.

