### PR TITLE
CPU/Memory improvement: Replaced Array.concat where possible with Array.push(...) which is way faster

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ setuptools.setup(
             'openvino.js', 'openvino-metadata.json', 'openvino-parser.js',
             'paddle.js', 'paddle-metadata.json', 'paddle-proto.js',
             'pytorch.js', 'pytorch-metadata.json', 'python.js',
+            'snapml.js', 'snapml-metadata.js', 'snapml-proto.js',
             'sklearn.js', 'sklearn-metadata.json',
             'tengine.js', 'tengine-metadata.json', 
             'uff.js', 'uff-metadata.json', 'uff-proto.js',

--- a/source/caffe.js
+++ b/source/caffe.js
@@ -510,7 +510,7 @@ caffe.Node = class {
                 }
             }
         }
-        this._inputs = this._inputs.concat(inputs.slice(inputIndex).map((input) => {
+        this._inputs.push(...inputs.slice(inputIndex).map((input) => {
             return new caffe.Parameter(inputIndex.toString(), [
                 input instanceof caffe.Tensor ? new caffe.Argument('', input.type, input) : new caffe.Argument(input, null, null)
             ]);
@@ -530,7 +530,7 @@ caffe.Node = class {
                 }
             }
         }
-        this._outputs = this._outputs.concat(outputs.slice(outputIndex).map((output, index) => {
+        this._outputs.push(outputs.slice(outputIndex).map((output, index) => {
             return new caffe.Parameter((outputIndex + index).toString(), [
                 new caffe.Argument(output, null, null)
             ]);

--- a/source/caffe.js
+++ b/source/caffe.js
@@ -530,7 +530,7 @@ caffe.Node = class {
                 }
             }
         }
-        this._outputs.push(outputs.slice(outputIndex).map((output, index) => {
+        this._outputs.push(...outputs.slice(outputIndex).map((output, index) => {
             return new caffe.Parameter((outputIndex + index).toString(), [
                 new caffe.Argument(output, null, null)
             ]);

--- a/source/caffe2.js
+++ b/source/caffe2.js
@@ -475,7 +475,7 @@ caffe2.Node = class {
             }
         }
         else {
-            this._inputs = this._inputs.concat(inputs.slice(inputIndex).map((input, index) => {
+            this._inputs.push(...inputs.slice(inputIndex).map((input, index) => {
                 const inputName = ((inputIndex + index) == 0) ? 'input' : (inputIndex + index).toString();
                 return new caffe2.Parameter(inputName, [
                     new caffe2.Argument(input, null, tensors[input])
@@ -496,7 +496,7 @@ caffe2.Node = class {
             }
         }
         else {
-            this._outputs = this._outputs.concat(outputs.slice(outputIndex).map((output, index) => {
+            this._outputs.push(...outputs.slice(outputIndex).map((output, index) => {
                 const outputName = ((outputIndex + index) == 0) ? 'output' : (outputIndex + index).toString();
                 return new caffe2.Parameter(outputName, [
                     new caffe2.Argument(output, null, null)

--- a/source/cntk.js
+++ b/source/cntk.js
@@ -434,7 +434,7 @@ cntk.Node = class {
                     }
                 }
                 outputs.push(new cntk.Argument(version, output + '_Output_0'));
-                inputs = inputs.concat(initializers);
+                inputs.push(...initializers);
                 break;
             }
         }
@@ -456,7 +456,7 @@ cntk.Node = class {
                 }
             }
         }
-        this._inputs = this._inputs.concat(inputs.slice(inputIndex).map((argument, index) => {
+        this._inputs.push(...inputs.slice(inputIndex).map((argument, index) => {
             return new cntk.Parameter((inputIndex + index).toString(), [ argument ]);
         }));
 
@@ -470,7 +470,7 @@ cntk.Node = class {
                 }
             }
         }
-        this._outputs = this._outputs.concat(outputs.slice(outputIndex).map((argument) => {
+        this._outputs.push(...outputs.slice(outputIndex).map((argument) => {
             return new cntk.Parameter(outputIndex.toString(), [ argument ]);
         }));
     }

--- a/source/coreml.js
+++ b/source/coreml.js
@@ -620,7 +620,7 @@ coreml.Node = class {
                 return new coreml.Argument(argument.name, argument.type, null, null);
             }));
         });
-        this._inputs = this._inputs.concat(initializers);
+        this._inputs.push(...initializers);
         this._outputs = outputs.map((output, index) => {
             const name = this._metadata.getOutputName(this._type, index);
             return new coreml.Parameter(name, true, [ new coreml.Argument(output, null, null, null) ]);

--- a/source/darknet.js
+++ b/source/darknet.js
@@ -405,9 +405,9 @@ darknet.Graph = class {
                         make_convolutional_layer(layer.self_layer, 'self_', params.h, params.w, hidden_filters, hidden_filters, groups, size, stride, stride, padding, batch_normalize);
                         layer.output_layer = { weights: [], outputs: layer.outputs };
                         make_convolutional_layer(layer.output_layer, 'output_', params.h, params.w, hidden_filters, output_filters, groups, size, stride, stride, padding, batch_normalize);
-                        layer.weights = layer.weights.concat(layer.input_layer.weights);
-                        layer.weights = layer.weights.concat(layer.self_layer.weights);
-                        layer.weights = layer.weights.concat(layer.output_layer.weights);
+                        layer.weights.push(...layer.input_layer.weights);
+                        layer.weights.push(...layer.self_layer.weights);
+                        layer.weights.push(...layer.output_layer.weights);
                         layer.out_h = layer.output_layer.out_h;
                         layer.out_w = layer.output_layer.out_w;
                         layer.out_c = output_filters;
@@ -425,9 +425,9 @@ darknet.Graph = class {
                         make_connected_layer(layer.self_layer, 'self_', hidden, hidden, batch_normalize);
                         layer.output_layer = { weights: [], outputs: layer.outputs };
                         make_connected_layer(layer.output_layer, 'output_', hidden, outputs, batch_normalize);
-                        layer.weights = layer.weights.concat(layer.input_layer.weights);
-                        layer.weights = layer.weights.concat(layer.self_layer.weights);
-                        layer.weights = layer.weights.concat(layer.output_layer.weights);
+                        layer.weights.push(...layer.input_layer.weights);
+                        layer.weights.push(...layer.self_layer.weights);
+                        layer.weights.push(...layer.output_layer.weights);
                         layer.out_w = 1;
                         layer.out_h = 1;
                         layer.out_c = outputs;
@@ -450,12 +450,12 @@ darknet.Graph = class {
                         make_connected_layer(layer.input_h_layer, 'input_h', inputs, outputs, batch_normalize);
                         layer.state_h_layer = { weights: [], outputs: [ new darknet.Argument('', null, null) ] };
                         make_connected_layer(layer.state_h_layer, 'state_h', outputs, outputs, batch_normalize);
-                        layer.weights = layer.weights.concat(layer.input_z_layer.weights);
-                        layer.weights = layer.weights.concat(layer.state_z_layer.weights);
-                        layer.weights = layer.weights.concat(layer.input_r_layer.weights);
-                        layer.weights = layer.weights.concat(layer.state_r_layer.weights);
-                        layer.weights = layer.weights.concat(layer.input_h_layer.weights);
-                        layer.weights = layer.weights.concat(layer.state_h_layer.weights);
+                        layer.weights.push(...layer.input_z_layer.weights);
+                        layer.weights.push(...layer.state_z_layer.weights);
+                        layer.weights.push(...layer.input_r_layer.weights);
+                        layer.weights.push(...layer.state_r_layer.weights);
+                        layer.weights.push(...layer.input_h_layer.weights);
+                        layer.weights.push(...layer.state_h_layer.weights);
                         layer.out = outputs;
                         layer.outputs[0].type = new darknet.TensorType('float32', make_shape([ outputs ], 'gru'));
                         break;
@@ -480,14 +480,14 @@ darknet.Graph = class {
                         make_connected_layer(layer.wg, 'wg_', outputs, outputs, batch_normalize);
                         layer.wo = { weights: [], outputs: [ new darknet.Argument('', null, null) ] };
                         make_connected_layer(layer.wo, 'wo_', outputs, outputs, batch_normalize);
-                        layer.weights = layer.weights.concat(layer.uf.weights);
-                        layer.weights = layer.weights.concat(layer.ui.weights);
-                        layer.weights = layer.weights.concat(layer.ug.weights);
-                        layer.weights = layer.weights.concat(layer.uo.weights);
-                        layer.weights = layer.weights.concat(layer.wf.weights);
-                        layer.weights = layer.weights.concat(layer.wi.weights);
-                        layer.weights = layer.weights.concat(layer.wg.weights);
-                        layer.weights = layer.weights.concat(layer.wo.weights);
+                        layer.weights.push(...layer.uf.weights);
+                        layer.weights.push(...layer.ui.weights);
+                        layer.weights.push(...layer.ug.weights);
+                        layer.weights.push(...layer.uo.weights);
+                        layer.weights.push(...layer.wf.weights);
+                        layer.weights.push(...layer.wi.weights);
+                        layer.weights.push(...layer.wg.weights);
+                        layer.weights.push(...layer.wo.weights);
                         layer.out_w = 1;
                         layer.out_h = 1;
                         layer.out_c = outputs;
@@ -514,14 +514,14 @@ darknet.Graph = class {
                         make_convolutional_layer(layer.ug, 'ug_', params.h, params.w, params.c, output_filters, groups, size, stride, stride, padding, batch_normalize);
                         layer.uo = { weights: [], outputs: [ new darknet.Argument('', null, null) ] };
                         make_convolutional_layer(layer.uo, 'uo_', params.h, params.w, params.c, output_filters, groups, size, stride, stride, padding, batch_normalize);
-                        layer.weights = layer.weights.concat(layer.uf.weights);
-                        layer.weights = layer.weights.concat(layer.ui.weights);
-                        layer.weights = layer.weights.concat(layer.ug.weights);
-                        layer.weights = layer.weights.concat(layer.uo.weights);
+                        layer.weights.push(...layer.uf.weights);
+                        layer.weights.push(...layer.ui.weights);
+                        layer.weights.push(...layer.ug.weights);
+                        layer.weights.push(...layer.uo.weights);
                         if (bottleneck) {
                             layer.wf = { weights: [], outputs: [ new darknet.Argument('', null, null) ] };
                             make_convolutional_layer(layer.wf, 'wf_', params.h, params.w, output_filters * 2, output_filters, groups, size, stride, stride, padding, batch_normalize);
-                            layer.weights = layer.weights.concat(layer.wf.weights);
+                            layer.weights.push(...layer.wf.weights);
                         }
                         else {
                             layer.wf = { weights: [], outputs: [ new darknet.Argument('', null, null) ] };
@@ -532,10 +532,10 @@ darknet.Graph = class {
                             make_convolutional_layer(layer.wg, 'wg_', params.h, params.w, output_filters, output_filters, groups, size, stride, stride, padding, batch_normalize);
                             layer.wo = { weights: [], outputs: [ new darknet.Argument('', null, null) ] };
                             make_convolutional_layer(layer.wo, 'wo_', params.h, params.w, output_filters, output_filters, groups, size, stride, stride, padding, batch_normalize);
-                            layer.weights = layer.weights.concat(layer.wf.weights);
-                            layer.weights = layer.weights.concat(layer.wi.weights);
-                            layer.weights = layer.weights.concat(layer.wg.weights);
-                            layer.weights = layer.weights.concat(layer.wo.weights);
+                            layer.weights.push(...layer.wf.weights);
+                            layer.weights.push(...layer.wi.weights);
+                            layer.weights.push(...layer.wg.weights);
+                            layer.weights.push(...layer.wo.weights);
                         }
                         if (peephole) {
                             layer.vf = { weights: [], outputs: [ new darknet.Argument('', null, null) ] };
@@ -544,9 +544,9 @@ darknet.Graph = class {
                             make_convolutional_layer(layer.vi, 'vi_', params.h, params.w, output_filters, output_filters, groups, size, stride, stride, padding, batch_normalize);
                             layer.vo = { weights: [], outputs: [ new darknet.Argument('', null, null) ] };
                             make_convolutional_layer(layer.wo, 'vo_', params.h, params.w, output_filters, output_filters, groups, size, stride, stride, padding, batch_normalize);
-                            layer.weights = layer.weights.concat(layer.vf.weights);
-                            layer.weights = layer.weights.concat(layer.vi.weights);
-                            layer.weights = layer.weights.concat(layer.vo.weights);
+                            layer.weights.push(...layer.vf.weights);
+                            layer.weights.push(...layer.vi.weights);
+                            layer.weights.push(...layer.vo.weights);
                         }
                         layer.out_h = layer.uo.out_h;
                         layer.out_w = layer.uo.out_w;

--- a/source/darknet.js
+++ b/source/darknet.js
@@ -826,7 +826,7 @@ darknet.Node = class {
             this._inputs.push(new darknet.Parameter(layer.inputs.length <= 1 ? 'input' : 'inputs', true, layer.inputs));
         }
         if (layer && layer.weights && layer.weights.length > 0) {
-            this._inputs = this._inputs.concat(layer.weights);
+            this._inputs.push(...layer.weights);
         }
         if (layer && layer.outputs && layer.outputs.length > 0) {
             this._outputs.push(new darknet.Parameter(layer.outputs.length <= 1 ? 'output' : 'outputs', true, layer.outputs));

--- a/source/hdf5.js
+++ b/source/hdf5.js
@@ -1316,7 +1316,7 @@ hdf5.Tree = class {
                     }
                     else {
                         const tree = new hdf5.Tree(reader.at(childPointer));
-                        this.nodes = this.nodes.concat(tree.nodes);
+                        this.nodes.push(...tree.nodes);
                     }
                 }
                 break;
@@ -1335,7 +1335,7 @@ hdf5.Tree = class {
                     }
                     else {
                         const tree = new hdf5.Tree(reader.at(childPointer), dimensionality);
-                        this.nodes = this.nodes.concat(tree.nodes);
+                        this.nodes.push(...tree.nodes);
                     }
                 }
                 break;

--- a/source/keras.js
+++ b/source/keras.js
@@ -1141,7 +1141,7 @@ keras.Group = class {
                     if (!chunk) {
                         break;
                     }
-                    value = value.concat(chunk);
+                    value.push(...chunk);
                     index++;
                 }
             }

--- a/source/mxnet.js
+++ b/source/mxnet.js
@@ -695,7 +695,7 @@ mxnet.Node = class {
                 }
             }
             if (inputIndex < inputs.length) {
-                this._inputs = this._inputs.concat(inputs.slice(inputIndex).map((input, index) => {
+                this._inputs.push(...inputs.slice(inputIndex).map((input, index) => {
                     const inputId = '[' + input.join(',') + ']';
                     return new mxnet.Parameter((inputIndex + index).toString(), [
                         new mxnet.Argument(inputId, null, initializers[inputId])
@@ -721,7 +721,7 @@ mxnet.Node = class {
                 }
             }
             if (outputIndex < outputs.length) {
-                this._outputs = this._outputs.concat(outputs.slice(outputIndex).map((output, index) => {
+                this._outputs.push(...outputs.slice(outputIndex).map((output, index) => {
                     return new mxnet.Parameter((outputIndex + index).toString(), [
                         new mxnet.Argument('[' + output.join(',') + ']', null, null)
                     ]);

--- a/source/ncnn.js
+++ b/source/ncnn.js
@@ -231,7 +231,7 @@ ncnn.Node = class {
                 }
             }
         }
-        this._inputs = this._inputs.concat(inputs.slice(inputIndex).map((input, index) => {
+        this._inputs.push(...inputs.slice(inputIndex).map((input, index) => {
             const inputName = ((inputIndex + index) == 0) ? 'input' : (inputIndex + index).toString();
             return new ncnn.Parameter(inputName, true, [
                 new ncnn.Argument(input, null, null)
@@ -252,7 +252,7 @@ ncnn.Node = class {
                 }
             }
         }
-        this._outputs = this._outputs.concat(outputs.slice(outputIndex).map((output, index) => {
+        this._outputs.push(...outputs.slice(outputIndex).map((output, index) => {
             const outputName = ((outputIndex + index) == 0) ? 'output' : (outputIndex + index).toString();
             return new ncnn.Parameter(outputName, true, [
                 new ncnn.Argument(output, null, null)

--- a/source/onnx.js
+++ b/source/onnx.js
@@ -362,7 +362,7 @@ onnx.Graph = class {
                         }
                     }
                     else {
-                        inputs = inputs.concat(node.input.slice(inputIndex).map((id, index) => {
+                        inputs.push(...node.input.slice(inputIndex).map((id, index) => {
                             return new onnx.Parameter((inputIndex + index).toString(), [
                                 arg(id, null, null, null, imageFormat)
                             ]);
@@ -385,7 +385,7 @@ onnx.Graph = class {
                         }
                     }
                     else {
-                        outputs = outputs.concat(node.output.slice(outputIndex).map((id, index) => {
+                        outputs.push(...node.output.slice(outputIndex).map((id, index) => {
                             return new onnx.Parameter((outputIndex + index).toString(), [
                                 arg(id, null, null, null, imageFormat)
                             ]);

--- a/source/onnx.js
+++ b/source/onnx.js
@@ -345,7 +345,7 @@ onnx.Graph = class {
                 this._outputs.push(new onnx.Parameter(valueInfo.name, [ argument ]));
             }
             for (const node of nodes) {
-                let inputs = [];
+                const inputs = [];
                 const schema = metadata.type(node.op_type);
                 if (node.input && node.input.length > 0) {
                     let inputIndex = 0;
@@ -369,7 +369,7 @@ onnx.Graph = class {
                         }));
                     }
                 }
-                let outputs = [];
+                const outputs = [];
                 if (node.output && node.output.length > 0) {
                     let outputIndex = 0;
                     if (schema && schema.outputs) {

--- a/source/pytorch.js
+++ b/source/pytorch.js
@@ -1978,7 +1978,7 @@ pytorch.Execution = class {
                         let loop = [];
                         for (const value of range) {
                             loop.push({ type: '=', target: variable, expression: { type: 'number', value: value }});
-                            loop = loop.concat(statement.body.statements);
+                            loop.push(...statement.body.statements);
                         }
                         statements = loop.concat(statements);
                         break;
@@ -2727,11 +2727,11 @@ pytorch.Container.Zip = class {
                         }
                         let parameters = [];
                         if (module.parameters) {
-                            parameters = parameters.concat(module.parameters);
+                            parameters.push(...module.parameters);
                             delete module.parameters;
                         }
                         if (module.arguments) {
-                            parameters = parameters.concat(module.arguments);
+                            parameters.push(...module.arguments);
                             delete module.arguments;
                         }
                         for (const parameter of parameters) {

--- a/source/pytorch.js
+++ b/source/pytorch.js
@@ -1975,7 +1975,7 @@ pytorch.Execution = class {
                         statement.variable.length === 1 && statement.variable[0].type === 'id') {
                         const range = this.expression(statement.target[0], context);
                         const variable = statement.variable[0];
-                        let loop = [];
+                        const loop = [];
                         for (const value of range) {
                             loop.push({ type: '=', target: variable, expression: { type: 'number', value: value }});
                             loop.push(...statement.body.statements);
@@ -2725,7 +2725,7 @@ pytorch.Container.Zip = class {
                             }
                             delete module.submodules;
                         }
-                        let parameters = [];
+                        const parameters = [];
                         if (module.parameters) {
                             parameters.push(...module.parameters);
                             delete module.parameters;

--- a/source/sklearn.js
+++ b/source/sklearn.js
@@ -133,7 +133,7 @@ sklearn.Graph = class {
                     value: value
                 });
             }
-            this._nodes = this._nodes.concat(groups.map((group) => {
+            this._nodes.push(...groups.map((group) => {
                 const inputs = group.arrays.map((array) => {
                     return new sklearn.Parameter(array.name, [
                         new sklearn.Argument(array.key, null, new sklearn.Tensor(array.key, array.value))
@@ -163,7 +163,7 @@ sklearn.Graph = class {
                 const subgroup = this._concat(group, name);
                 this._add(subgroup, output, obj, inputs, [ output ]);
                 for (const transformer of obj.transformer_list){
-                    outputs = outputs.concat(this._process(subgroup, transformer[0], transformer[1], [ output ]));
+                    outputs.push(...this._process(subgroup, transformer[0], transformer[1], [ output ]));
                 }
                 return outputs;
             }
@@ -175,7 +175,7 @@ sklearn.Graph = class {
                 let outputs = [];
                 this._add(subgroup, output, obj, inputs, [ output ]);
                 for (const transformer of obj.transformers){
-                    outputs = outputs.concat(this._process(subgroup, transformer[0], transformer[1], [ output ]));
+                    outputs.push(...this._process(subgroup, transformer[0], transformer[1], [ output ]));
                 }
                 return outputs;
             }
@@ -200,7 +200,7 @@ sklearn.Graph = class {
         inputs = inputs.map((input) => {
             return new sklearn.Parameter(input, [ new sklearn.Argument(input, null, null) ]);
         });
-        inputs = inputs.concat(initializers.map((initializer) => {
+        inputs.push(...initializers.map((initializer) => {
             return new sklearn.Parameter(initializer.name, [ new sklearn.Argument('', null, initializer) ]);
         }));
         outputs = outputs.map((output) => {

--- a/source/sklearn.js
+++ b/source/sklearn.js
@@ -157,10 +157,10 @@ sklearn.Graph = class {
             }
             case 'sklearn.pipeline.FeatureUnion': {
                 this._groups = true;
-                let outputs = [];
                 name = name || 'union';
                 const output = this._concat(group, name);
                 const subgroup = this._concat(group, name);
+                const outputs = [];
                 this._add(subgroup, output, obj, inputs, [ output ]);
                 for (const transformer of obj.transformer_list){
                     outputs.push(...this._process(subgroup, transformer[0], transformer[1], [ output ]));
@@ -172,7 +172,7 @@ sklearn.Graph = class {
                 name = name || 'transformer';
                 const output = this._concat(group, name);
                 const subgroup = this._concat(group, name);
-                let outputs = [];
+                const outputs = [];
                 this._add(subgroup, output, obj, inputs, [ output ]);
                 for (const transformer of obj.transformers){
                     outputs.push(...this._process(subgroup, transformer[0], transformer[1], [ output ]));

--- a/source/snapml.js
+++ b/source/snapml.js
@@ -1,0 +1,33 @@
+/* jshint esversion: 6 */
+
+var snapml = snapml || {};
+
+snapml.ModelFactory = class {
+
+    match(context) {
+        const extension = context.identifier.split('.').pop().toLowerCase();
+        if (extension == 'dnn') {
+            const tags = context.tags('pb');
+            if (tags.get(2) == 0 && tags.get(4) == 0 && tags.get(10) == 2) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    open(context, host) {
+        throw new snapml.Error("File contains undocumented SnapML data in '" + context.identifier + "'.");
+    }
+};
+
+snapml.Error = class extends Error {
+
+    constructor(message) {
+        super(message);
+        this.name = 'Error loading SnapML model.';
+    }
+};
+
+if (typeof module !== 'undefined' && typeof module.exports === 'object') {
+    module.exports.ModelFactory = snapml.ModelFactory;
+}

--- a/source/tengine.js
+++ b/source/tengine.js
@@ -191,7 +191,7 @@ tengine.Node = class {
             }
         }
         else {
-            this._inputs = this._inputs.concat(inputs.slice(inputIndex).map((id, index) => {
+            this._inputs.push(...inputs.slice(inputIndex).map((id, index) => {
                 const inputName = ((inputIndex + index) == 0) ? 'input' : (inputIndex + index).toString();
                 return new tengine.Parameter(inputName, true, [ tensors[id] ]);
             }));
@@ -210,7 +210,7 @@ tengine.Node = class {
             }
         }
         else {
-            this._outputs = this._outputs.concat(outputs.slice(outputIndex).map((id, index) => {
+            this._outputs.push(...outputs.slice(outputIndex).map((id, index) => {
                 const outputName = ((outputIndex + index) == 0) ? 'output' : (outputIndex + index).toString();
                 return new tengine.Parameter(outputName, true, [ tensors[id] ]);
             }));

--- a/source/tf.js
+++ b/source/tf.js
@@ -804,7 +804,7 @@ tf.Node = class {
                     inputIndex += inputCount;
                 }
             }
-            this._inputs = this._inputs.concat(inputs.slice(inputIndex).map((input, index) => {
+            this._inputs.push(...inputs.slice(inputIndex).map((input, index) => {
                 return new tf.Parameter((inputIndex + index).toString(), [
                     new tf.Argument(input, null, initializers[input])
                 ]);
@@ -833,7 +833,7 @@ tf.Node = class {
                     outputIndex += outputCount;
                 }
             }
-            this._outputs = this._outputs.concat(outputs.slice(outputIndex).map((output, index) => {
+            this._outputs.push(...outputs.slice(outputIndex).map((output, index) => {
                 return new tf.Parameter((outputIndex + index).toString(), [
                     new tf.Argument(output, null, null)
                 ]);
@@ -1373,7 +1373,7 @@ tf.TensorBundle = class {
                             const item = data.get(name);
                             if (item !== null) {
                                 if (tensor[item.key] && tensor[item.key].length > 0) {
-                                    item.value = item.value.concat(tensor[item.key]);
+                                    item.value.push(...tensor[item.key]);
                                 }
                                 else {
                                     data.set(name, null);

--- a/source/tnn.js
+++ b/source/tnn.js
@@ -203,7 +203,7 @@ tnn.Node = class {
             }
         }
         else {
-            this._inputs = this._inputs.concat(inputs.slice(inputIndex).map((input, index) => {
+            this._inputs.push(...inputs.slice(inputIndex).map((input, index) => {
                 const inputName = ((inputIndex + index) == 0) ? 'input' : (inputIndex + index).toString();
                 return new tnn.Parameter(inputName, [ new tnn.Argument(input, null, null) ]);
             }));
@@ -224,7 +224,7 @@ tnn.Node = class {
             }
         }
         else {
-            this._outputs = this._outputs.concat(outputs.slice(outputIndex).map((output, index) => {
+            this._outputs.push(...outputs.slice(outputIndex).map((output, index) => {
                 const outputName = ((outputIndex + index) == 0) ? 'output' : (outputIndex + index).toString();
                 return new tnn.Parameter(outputName, [ new tnn.Argument(output, null, null) ]);
             }));

--- a/source/torch.js
+++ b/source/torch.js
@@ -123,8 +123,8 @@ torch.Graph = class {
             case 'nn.ParallelTable':
             case 'nn.JointTrain': {
                 groups.push(key);
-                let newInputs = [];
-                let newOutputs = [];
+                const newInputs = [];
+                const newOutputs = [];
                 let index = 0;
                 for (const subModule of module.modules) {
                     const subInputs = [].concat(inputs);
@@ -151,7 +151,7 @@ torch.Graph = class {
                 if (inputs.length == 0) {
                     inputs.push(new torch.Argument(groups.join('/') + ':' + key + ':in', null, null));
                 }
-                let concatInputs = [];
+                const concatInputs = [];
                 let index = 0;
                 for (const subModule of module.modules) {
                     const streamInputs = inputs.map((input) => input);

--- a/source/torch.js
+++ b/source/torch.js
@@ -72,10 +72,10 @@ torch.Graph = class {
         const outputs = [];
         this._loadModule(metadata, root, [], '', inputs, outputs);
 
-        this._inputs = this._inputs.concat(inputs.map((input, index) => {
+        this._inputs.push(...inputs.map((input, index) => {
             return new torch.Parameter('input' + (index != 0 ? (index + 1).toString() : ''), true, [ input ]);
         }));
-        this._outputs = this._outputs.concat(outputs.map((output, index) => {
+        this._outputs.push(...outputs.map((output, index) => {
             return new torch.Parameter('output' + (index != 0 ? (index + 1).toString() : ''), true, [ output ]);
         }));
     }
@@ -131,14 +131,14 @@ torch.Graph = class {
                     const subOutputs = [].concat(outputs);
                     this._loadModule(metadata, subModule, groups, index.toString(), subInputs, subOutputs);
                     if (inputs.length == 0) {
-                        newInputs = newInputs.concat(subInputs);
+                        newInputs.push(...subInputs);
                     }
                     if (outputs.length == 0) {
-                        newOutputs = newOutputs.concat(subOutputs);
+                        newOutputs.push(...subOutputs);
                     }
                     index++;
                 }
-                inputs = inputs.concat(newInputs);
+                inputs.push(...newInputs);
                 for (const newOutput of newOutputs) {
                     outputs.push(newOutput);
                 }
@@ -157,7 +157,7 @@ torch.Graph = class {
                     const streamInputs = inputs.map((input) => input);
                     const streamOutputs = [];
                     this._loadModule(metadata, subModule, groups, prefix + '.' + index.toString(), streamInputs, streamOutputs);
-                    concatInputs = concatInputs.concat(streamOutputs);
+                    concatInputs.push(...streamOutputs);
                     index++;
                 }
                 delete module.modules;
@@ -389,7 +389,7 @@ torch.Node = class {
             }
             return true;
         });
-        this._inputs = this._inputs.concat(initializers);
+        this._inputs.push(...initializers);
     }
 
     get name() {

--- a/source/uff.js
+++ b/source/uff.js
@@ -241,7 +241,7 @@ uff.Node = class {
                     }
                 }
             }
-            this._inputs = this._inputs.concat(node.inputs.slice(inputIndex).map((id, index) => {
+            this._inputs.push(...node.inputs.slice(inputIndex).map((id, index) => {
                 const inputName = ((inputIndex + index) == 0) ? 'input' : (inputIndex + index).toString();
                 return new uff.Parameter(inputName, [ args.get(id) ]);
             }));

--- a/source/view-grapher.js
+++ b/source/view-grapher.js
@@ -310,14 +310,14 @@ grapher.NodeElement.Header = class {
             const yPadding = 4;
             const xPadding = 7;
             const element = this.createElement('g');
-            let classList = [ 'node-item' ];
+            const classList = [ 'node-item' ];
             parentElement.appendChild(element);
             const pathElement = this.createElement('path');
             const textElement = this.createElement('text');
             element.appendChild(pathElement);
             element.appendChild(textElement);
             if (item.classList) {
-                classList = classList.concat(item.classList);
+                classList.push(...item.classList);
             }
             element.setAttribute('class', classList.join(' '));
             if (item.id) {

--- a/source/view.js
+++ b/source/view.js
@@ -1211,6 +1211,7 @@ view.ModelFactoryService = class {
         this.register('./tnn', [ '.tnnproto', '.tnnmodel' ]);
         this.register('./tengine', ['.tmfile']);
         this.register('./barracuda', [ '.nn' ]);
+        this.register('./snapml', [ '.dnn' ]);
         this.register('./openvino', [ '.xml', '.bin' ]);
         this.register('./flux', [ '.bson' ]);
         this.register('./npz', [ '.npz', '.h5', '.hd5', '.hdf5' ]);

--- a/test/models.js
+++ b/test/models.js
@@ -222,10 +222,10 @@ class HTMLElement {
     }
 
     getElementsByClassName(name) {
-        let elements = [];
+        const elements = [];
         for (const node of this._childNodes) {
             if (node instanceof HTMLElement) {
-                elements = elements.concat(node.getElementsByClassName(name));
+                elements.push(...node.getElementsByClassName(name));
                 if (node.hasAttribute('class') &&
                     node.getAttribute('class').split(' ').find((text) => text === name)) {
                     elements.push(node);

--- a/test/models.json
+++ b/test/models.json
@@ -4542,6 +4542,13 @@
     "link":   "https://github.com/lutzroeder/netron/issues/182"
   },
   {
+    "type":   "snapml",
+    "target": "brows_model.dnn",
+    "source": "https://github.com/lutzroeder/netron/files/5118426/brows_model.zip[brows_model.dnn]",
+    "error":  "File contains undocumented SnapML data in 'brows_model.dnn'.",
+    "link":   "https://github.com/lutzroeder/netron/issues/581"
+  },
+  {
     "type":   "tengine",
     "target": "detect_tflite.tmfile",
     "source": "https://raw.githubusercontent.com/pierricklee/tmfile-sample/master/detect_tflite.tmfile",


### PR DESCRIPTION
Performance and memory improvement: where possible I replaced the Array.concat with Array.push.
According to [this](https://dev.to/uilicious/javascript-array-push-is-945x-faster-than-array-concat-1oki) Array.push is way faster.
```
The improvement has a lot to do with the fact that Array.concat creates a new array while Array.push modifies the first array. The additional work Array.concat does to add the elements from the first array to the returned array is the main reason for the slowdown.
```
![image](https://user-images.githubusercontent.com/1175820/91159423-bd325580-e6d0-11ea-88ba-298b7a5594b4.png)
