### PR TITLE
Make paddlepaddle subgraph selectable.

### DIFF
--- a/source/paddle.js
+++ b/source/paddle.js
@@ -90,6 +90,7 @@ paddle.Graph = class {
         this._nodes = [];
         this._inputs = [];
         this._outputs = [];
+        this._name = "blocks[" + block.idx + "]";
 
         const args = new Map();
         for (const variable of block.vars) {
@@ -166,6 +167,11 @@ paddle.Graph = class {
                 }
             }
         }
+    }
+
+    // name() is required for select subgraph
+    get name() {
+        return this._name;
     }
 
     get inputs() {


### PR DESCRIPTION
The `paddle.Graph` class didn't provide  `name()` member function. All of the paddle subgraphs have an identical name "`undefined`".  So we cannot switch paddle subgraphs according to subgraph name.

![image](https://user-images.githubusercontent.com/1180139/91844772-99e84700-ec8a-11ea-9bad-10f4ef7d1555.png)

This change add `name()` function to `paddle.Graph`. Then the subgraphs can be selected and switched, as shown bellow:

![image](https://user-images.githubusercontent.com/1180139/91844896-d61ba780-ec8a-11ea-8ee5-9d414ce056f4.png)


