### PR TITLE
fix bug: multi-input/output for Tengine

### DIFF
--- a/source/tengine.js
+++ b/source/tengine.js
@@ -79,7 +79,7 @@ tengine.Graph = class {
         }
 
         for (const node of graph.nodes) {
-            if (node.type !== 'INPUT') {
+            if (node.type !== 'INPUT' && node.type !== 'Const') {
                 this._nodes.push(new tengine.Node(metadata, node, tensors));
             }
         }
@@ -653,8 +653,10 @@ tengine.ModelFileReader = class {
             }
             */
             subgraph.originalLayout = reader.int32();
-            subgraph.inputs = reader.uint32s();
-            subgraph.outputs = reader.uint32s();
+            const inputNodes = reader.uint32s(); 
+            const outputNodes = reader.uint32s();
+            subgraph.inputs = [];
+            subgraph.outputs = [];
             const nodeOffsets = reader.uint32s();
             const tensorOffsets = reader.uint32s();
             const bufferOffsets = reader.uint32s();
@@ -731,9 +733,20 @@ tengine.ModelFileReader = class {
                     return { name: name, value: value, type: type };
                 });
 
-                if (node.type !== 'Const') {
+                // if (node.type !== 'Const') {
                     subgraph.nodes.push(node);
-                }
+                // }
+
+            }
+
+            // inputs
+            for (const inputNode of inputNodes) {
+                subgraph.inputs.push(subgraph.nodes[inputNode].outputs);
+            }
+
+            // outputs
+            for (const outputNode of outputNodes) {
+                subgraph.outputs.push(subgraph.nodes[outputNode].outputs);
             }
 
             // buffers


### PR DESCRIPTION
Hi Lutz,

When rendering multi-input or multi-output Tengine models, Netron failed like this : 
![image](https://user-images.githubusercontent.com/21244722/93574788-6b2cd900-f9cb-11ea-90a6-6fbf5d77462d.png)

While the real model is like :
![image](https://user-images.githubusercontent.com/21244722/93574972-a29b8580-f9cb-11ea-9b55-7e9afc90359a.png)

This is because in subgraph decoding, it gets `subgraph.inputs` are actually nodes but not tensors (also works for `subgraph.outputs`). 

I modified and successfully render like this :
![image](https://user-images.githubusercontent.com/21244722/93575328-16d62900-f9cc-11ea-9e25-6e58873f7576.png)

ChangeLog:
1. Allow `Const` operators be pushed into subgraph ;
2. Read real `graph inputs` and `graph outputs` by `node id` ; 
3. Do not render `Const` operators

Here is the `tmfile` model attached so you can test.
[test_multi_input_output.zip](https://github.com/lutzroeder/netron/files/5244386/test_multi_input_output.zip)



----------------
Thanks,

Pierrick