### PR TITLE
update tengine operator list

### DIFF
--- a/source/tengine-metadata.json
+++ b/source/tengine-metadata.json
@@ -1011,9 +1011,12 @@
     }
   },
   {
-    "name": "MatMul",
+    "name": "Unsqueeze",
     "schema": {
-      "category": "Layer"
+      "category": "Transform",
+      "attributes": [
+        { "name": "axises[]", "type": "int32[]", "default": [] }
+      ]
     }
   },
   {
@@ -1027,12 +1030,59 @@
     }
   },
   {
-    "name": "Unsqueeze",
+    "name": "Mean",
     "schema": {
-      "category": "Transform",
+      "category": "Layer"
+    }
+  },
+  {
+    "name": "MatMul",
+    "schema": {
+      "category": "Layer"
+    }
+  },
+  {
+    "name": "Expand",
+    "schema": {
+      "category": "Layer",
       "attributes": [
-        { "name": "axises[]", "type": "int32[]", "default": [] }
+        { "name": "v_shape[]", "type": "int32[]", "default": [] }
       ]
+    }
+  },
+  {
+    "name": "Scatter",
+    "schema": {
+      "category": "Layer",
+      "attributes": [
+        { "name": "axis", "type": "int32", "default": 0 },
+        { "name": "is_onnx", "type": "boolean", "default": false }
+
+      ]
+    }
+  },
+  {
+    "name": "Scatter",
+    "schema": {
+      "category": "Layer"
+    }
+  },
+  {
+    "name": "Shape",
+    "schema": {
+      "category": "Shape"
+    }
+  },
+  {
+    "name": "Where",
+    "schema": {
+      "category": "Layer"
+    }
+  },
+  {
+    "name": "Mish",
+    "schema": {
+      "category": "Activation"
     }
   },
   {

--- a/source/tengine.js
+++ b/source/tengine.js
@@ -623,10 +623,17 @@ tengine.ModelFileReader = class {
         register(85, 0, 'Round', []);
         register(86, 0, 'ZerosLike', []);
         register(87, 0, 'Clip', [ 'f','f' ]);
-        register(88, 0, 'MatMul', []);
+        register(88, 0, 'Unsqueeze', [ 'i[]' ]);
         register(89, 0, 'ReduceL2', [ 'i','i' ]);
-        register(90, 0, 'Unsqueeze', [ 'i[]' ]); /* need fix*/
-        register(91, 0, 'Num', []);
+        register(90, 0, 'Mean', []);
+        register(91, 0, 'MatMul', []);
+        register(92, 0, 'Expand', ['i[]']);
+        register(93, 0, 'Scatter', ['i','boolean']);
+        register(94, 0, 'Shape', []);
+        register(95, 0, 'Where', []);
+        register(96, 0, 'Tile', ['i','i']);
+        register(97, 0, 'Mish', []);
+        register(98, 0, 'Num', []);
 
         const reader = new tengine.BinaryReader(buffer);
         this._majorVersion = reader.uint16();


### PR DESCRIPTION
Update Tengine operator list by this: 
https://github.com/OAID/Tengine-Convert-Tools/blob/master/serializer/include/tengine/v2/tm2_format.h

The following operator list will be keeping pace with `Tengine-Convert-Tools`.
Changed the order of `Matmul` and `Unsqueeze` ( will also fix this in Tengine-Convert-Tools).