### PR TITLE
Fix Prototype Pollution

### DIFF
--- a/source/json.js
+++ b/source/json.js
@@ -108,6 +108,9 @@ json.TextReader = class {
                     this._next();
                     this._whitespace();
                     c = this._char;
+                    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+                      throw new json.Error('Attempted prototype pollution ' + key + this._location());
+                    }
                     switch (c) {
                         case '{': {
                             this._next();
@@ -477,6 +480,9 @@ json.BinaryReader = class {
                 obj.push(value);
             }
             else {
+                if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+                  throw new json.Error('Attempted prototype pollution ' + key + ' at ' + position.toString());
+                }
                 obj[key] = value;
             }
             if (type === 0x03 || type === 0x04) {


### PR DESCRIPTION
Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as _proto_, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

One of the `js` file to parse the `JSON` provided as datasets is vulnerable to a `prototype pollution` issue, which could lead to `DOS` or also `RCE` in special cases

Fixed by avoiding setting magical attributes.

### 🐛 Proof of Concept (PoC) *

1. Download the https://github.com/lutzroeder/netron repo
2. `cd <installation_dir>/source`
3. Create the POC file:

```js
// poc.js
var j_net = require('./json');
var res = new j_net.TextReader('{"__proto__":{"test":true}}').read();
console.log(res.__proto__.test);
```

Outputs true.

### 🔥 Proof of Fix (PoF) *

After fix execution will trow "Attempted prototype pollution: ... " and object will be not polluted

### 👍 User Acceptance Testing (UAT)

After fix functionality is unafected