### PR TITLE
Acuity support

### DIFF
--- a/source/acuity-metadata.json
+++ b/source/acuity-metadata.json
@@ -1,0 +1,3067 @@
+[
+  {
+    "name": "a_times_b_plus_c",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"},
+        {"name": "in2", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "abs",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "add",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "addn",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "argmin",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "axis", "default_value": -1, "description": "axis"}
+      ]
+    }
+  },
+  {
+    "name": "base_input_layer",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "batch2space",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "block_shape", "default_value": [2, 2], "description": "block_shape"},
+        {"name": "block_crops", "default_value": [
+          [0, 0],
+          [0, 0]
+        ], "description": "block_crops"}
+      ]
+    }
+  },
+  {
+    "name": "batchnorm_single",
+    "schema": {
+      "category": "Normalization",
+      "inputs": [
+        {"name": "in0", "description": "input"},
+        {"name": "in1", "description": "mean"},
+        {"name": "in2", "description": "variance"}
+      ],
+      "constants": [
+        {"name": "bias", "description": "bias"},
+        {"name": "scale", "description": "scale"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "eps", "default_value": 0.0001, "description": "eps"}
+      ]
+    }
+  },
+  {
+    "name": "batchnormalize",
+    "schema": {
+      "category": "Normalization",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "beta", "description": "beta"},
+        {"name": "gamma", "description": "gamma"},
+        {"name": "mean", "description": "mean"},
+        {"name": "variance", "description": "variance"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "eps", "default_value": 0.0001, "description": "eps"}
+      ]
+    }
+  },
+  {
+    "name": "capsule_norm",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "cast",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "in_data_type", "default_value": 0, "description": "in_data_type"},
+        {"name": "out_data_type", "default_value": 0, "description": "out_data_type"}
+      ]
+    }
+  },
+  {
+    "name": "clipbyvalue",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "clip_value_min", "default_value": 0, "description": "clip_value_min"},
+        {"name": "clip_value_max", "default_value": 255, "description": "clip_value_max"}
+      ]
+    }
+  },
+  {
+    "name": "concat",
+    "schema": {
+      "category": "Tensor",
+      "inputs": [],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "dim", "default_value": 1, "description": "dim"}
+      ]
+    }
+  },
+  {
+    "name": "concatshift",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "data"},
+        {"name": "out1", "description": "shifted_data"}
+      ],
+      "attributes": [
+        {"name": "dim", "default_value": 1, "description": "dim"},
+        {"name": "keep_size", "default_value": 1, "description": "keep_size"}
+      ]
+    }
+  },
+  {
+    "name": "continuationindicator",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "time_step", "default_value": 0, "description": "time_step"},
+        {"name": "batch_size", "default_value": 0, "description": "batch_size"}
+      ]
+    }
+  },
+  {
+    "name": "conv1d",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "weight", "description": "weight"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "weights", "default_value": 1, "description": "weights"},
+        {"name": "padding", "default_value": "VALID", "description": "padding"},
+        {"name": "bias", "default_value": true, "description": "bias"},
+        {"name": "group_number", "default_value": 1, "description": "group_number"},
+        {"name": "ksize", "default_value": 1, "description": "ksize"},
+        {"name": "stride", "default_value": 1, "description": "stride"},
+        {"name": "pad", "default_value": [0, 0], "description": "pad"},
+        {"name": "dilation", "default_value": [1, 1, 1], "description": "dilation"}
+      ]
+    }
+  },
+  {
+    "name": "conv2d_op",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "padding", "default_value": "VALID", "description": "padding"},
+        {"name": "group_number", "default_value": 1, "description": "group_number"},
+        {"name": "stride_h", "default_value": 1, "description": "stride_h"},
+        {"name": "stride_w", "default_value": 1, "description": "stride_w"},
+        {"name": "pad_h", "default_value": 0, "description": "pad_h"},
+        {"name": "pad_w", "default_value": 0, "description": "pad_w"},
+        {"name": "dilation", "default_value": [1, 1, 1], "description": "dilation"},
+        {"name": "pad_method", "default_value": "auto", "description": "pad_method"},
+        {"name": "pad", "default_value": [0, 0, 0, 0], "description": "pad"},
+        {"name": "pad_h_b", "default_value": 0, "description": "pad_h_b"},
+        {"name": "pad_w_r", "default_value": 0, "description": "pad_w_r"}
+      ]
+    }
+  },
+  {
+    "name": "conv3d",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "weight", "description": "weight"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "weights", "default_value": 1, "description": "weights"},
+        {"name": "bias", "default_value": false, "description": "bias"},
+        {"name": "group_number", "default_value": 1, "description": "group_number"},
+        {"name": "ksize_d", "default_value": 1, "description": "ksize_d"},
+        {"name": "ksize_h", "default_value": 1, "description": "ksize_h"},
+        {"name": "ksize_w", "default_value": 1, "description": "ksize_w"},
+        {"name": "stride_d", "default_value": 1, "description": "stride_d"},
+        {"name": "stride_h", "default_value": 1, "description": "stride_h"},
+        {"name": "stride_w", "default_value": 1, "description": "stride_w"},
+        {"name": "padding", "default_value": "VALID", "description": "padding"},
+        {"name": "pad_method", "default_value": "padding_const", "description": "pad_method"},
+        {"name": "pad", "default_value": [0, 0, 0, 0, 0, 0], "description": "pad"},
+        {"name": "dilation", "default_value": [1, 1, 1, 1, 1], "description": "dilation"}
+      ]
+    }
+  },
+  {
+    "name": "convolution",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "weight", "description": "weight"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "weights", "default_value": 1, "description": "weights"},
+        {"name": "padding", "default_value": "VALID", "description": "padding"},
+        {"name": "bias", "default_value": true, "description": "bias"},
+        {"name": "group_number", "default_value": 1, "description": "group_number"},
+        {"name": "regularize", "default_value": false, "description": "regularize"},
+        {"name": "ksize_h", "default_value": 1, "description": "ksize_h"},
+        {"name": "ksize_w", "default_value": 1, "description": "ksize_w"},
+        {"name": "stride_h", "default_value": 1, "description": "stride_h"},
+        {"name": "stride_w", "default_value": 1, "description": "stride_w"},
+        {"name": "pad_h", "default_value": 0, "description": "pad_h"},
+        {"name": "pad_w", "default_value": 0, "description": "pad_w"},
+        {"name": "dilation", "default_value": [1, 1, 1, 1], "description": "dilation"},
+        {"name": "pad_method", "default_value": "auto", "description": "pad_method"},
+        {"name": "pad", "default_value": [0, 0, 0, 0], "description": "pad"},
+        {"name": "pad_h_b", "default_value": 0, "description": "pad_h_b"},
+        {"name": "pad_w_r", "default_value": 0, "description": "pad_w_r"},
+        {"name": "multiplier", "default_value": 0, "description": "multiplier"}
+      ]
+    }
+  },
+  {
+    "name": "crop_image",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "crop_size", "default_value": [], "description": "crop_size"}
+      ]
+    }
+  },
+  {
+    "name": "cropandresize",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "boxes", "description": "boxes"},
+        {"name": "box_ind", "description": "box_ind"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "num_crop_boxes", "default_value": 0, "description": "num_crop_boxes"},
+        {"name": "crop_size", "default_value": [], "description": "crop_size"},
+        {"name": "resize_method", "default_value": "bilinear", "description": "resize_method"}
+      ]
+    }
+  },
+  {
+    "name": "ctc_loss_layer",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "time_major", "default_value": false, "description": "time_major"}
+      ]
+    }
+  },
+  {
+    "name": "customlayer",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [],
+      "attributes": []
+    }
+  },
+  {
+    "name": "deconvolution",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "weight", "description": "weight"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "weights", "default_value": 1, "description": "weights"},
+        {"name": "padding", "default_value": "VALID", "description": "padding"},
+        {"name": "bias", "default_value": true, "description": "bias"},
+        {"name": "group_number", "default_value": 1, "description": "group_number"},
+        {"name": "regularize", "default_value": false, "description": "regularize"},
+        {"name": "ksize_h", "default_value": 1, "description": "ksize_h"},
+        {"name": "ksize_w", "default_value": 1, "description": "ksize_w"},
+        {"name": "stride_h", "default_value": 1, "description": "stride_h"},
+        {"name": "stride_w", "default_value": 1, "description": "stride_w"},
+        {"name": "pad_h", "default_value": 0, "description": "pad_h"},
+        {"name": "pad_w", "default_value": 0, "description": "pad_w"},
+        {"name": "pad_method", "default_value": "auto", "description": "pad_method"},
+        {"name": "pad", "default_value": [0, 0, 0, 0], "description": "pad"},
+        {"name": "pad_h_b", "default_value": 0, "description": "pad_h_b"},
+        {"name": "pad_w_r", "default_value": 0, "description": "pad_w_r"},
+        {"name": "output_shape", "default_value": [], "description": "output_shape"},
+        {"name": "output_padding_h", "default_value": 0, "description": "output_padding_h"},
+        {"name": "output_padding_w", "default_value": 0, "description": "output_padding_w"}
+      ]
+    }
+  },
+  {
+    "name": "depth2space",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "block_size", "default_value": 2, "description": "block_size"},
+        {"name": "mode", "default_value": "DCR", "description": "mode"}
+      ]
+    }
+  },
+  {
+    "name": "depthwise_conv1d",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "weight", "description": "weight"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "weights", "default_value": 1, "description": "weights"},
+        {"name": "padding", "default_value": "VALID", "description": "padding"},
+        {"name": "bias", "default_value": true, "description": "bias"},
+        {"name": "group_number", "default_value": 2, "description": "group_number"},
+        {"name": "ksize", "default_value": 1, "description": "ksize"},
+        {"name": "stride", "default_value": 1, "description": "stride"},
+        {"name": "pad", "default_value": [0, 0], "description": "pad"},
+        {"name": "dilation", "default_value": [1, 1, 1], "description": "dilation"},
+        {"name": "multiplier", "default_value": 1, "description": "multiplier"}
+      ]
+    }
+  },
+  {
+    "name": "depthwise_conv2d_op",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "padding", "default_value": "VALID", "description": "padding"},
+        {"name": "ksize_h", "default_value": 1, "description": "ksize_h"},
+        {"name": "ksize_w", "default_value": 1, "description": "ksize_w"},
+        {"name": "stride_h", "default_value": 1, "description": "stride_h"},
+        {"name": "stride_w", "default_value": 1, "description": "stride_w"},
+        {"name": "dilation", "default_value": [1, 1, 1, 1], "description": "dilation"},
+        {"name": "multiplier", "default_value": 1, "description": "multiplier"},
+        {"name": "pad_method", "default_value": "auto", "description": "pad_method"},
+        {"name": "pad", "default_value": [0, 0, 0, 0], "description": "pad"},
+        {"name": "pad_h", "default_value": 0, "description": "pad_h"},
+        {"name": "pad_w", "default_value": 0, "description": "pad_w"},
+        {"name": "pad_h_b", "default_value": 0, "description": "pad_h_b"},
+        {"name": "pad_w_r", "default_value": 0, "description": "pad_w_r"}
+      ]
+    }
+  },
+  {
+    "name": "depthwise_convolution",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "weight", "description": "weight"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "weights", "default_value": 1, "description": "weights"},
+        {"name": "padding", "default_value": "VALID", "description": "padding"},
+        {"name": "bias", "default_value": true, "description": "bias"},
+        {"name": "regularize", "default_value": false, "description": "regularize"},
+        {"name": "ksize_h", "default_value": 1, "description": "ksize_h"},
+        {"name": "ksize_w", "default_value": 1, "description": "ksize_w"},
+        {"name": "stride_h", "default_value": 1, "description": "stride_h"},
+        {"name": "stride_w", "default_value": 1, "description": "stride_w"},
+        {"name": "dilation", "default_value": [1, 1, 1, 1], "description": "dilation"},
+        {"name": "multiplier", "default_value": 1, "description": "multiplier"},
+        {"name": "pad_method", "default_value": "auto", "description": "pad_method"},
+        {"name": "pad", "default_value": [0, 0, 0, 0], "description": "pad"},
+        {"name": "pad_h", "default_value": 0, "description": "pad_h"},
+        {"name": "pad_w", "default_value": 0, "description": "pad_w"},
+        {"name": "pad_h_b", "default_value": 0, "description": "pad_h_b"},
+        {"name": "pad_w_r", "default_value": 0, "description": "pad_w_r"}
+      ]
+    }
+  },
+  {
+    "name": "dequantize",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "detectionevaluate",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"},
+        {"name": "out1", "description": "out"},
+        {"name": "out2", "description": "out"},
+        {"name": "out3", "description": "out"},
+        {"name": "out4", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "detectionoutput",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"},
+        {"name": "in2", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "digit_capsule",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "weight", "description": "weight"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "num_output", "default_value": 1, "description": "num_output"},
+        {"name": "vec_len", "default_value": 1, "description": "vec_len"},
+        {"name": "iterations", "default_value": 3, "description": "iterations"}
+      ]
+    }
+  },
+  {
+    "name": "divide",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "dividend"},
+        {"name": "in1", "description": "divisor"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "dropout",
+    "schema": {
+      "category": "Dropout",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "ratio", "default_value": 0.5, "description": "ratio"},
+        {"name": "scale_train", "default_value": false, "description": "scale_train"}
+      ]
+    }
+  },
+  {
+    "name": "dtype_converter",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "eltwise",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "operation", "default_value": "SUM", "description": "operation"},
+        {"name": "coeff", "default_value": "", "description": "coeff"}
+      ]
+    }
+  },
+  {
+    "name": "elu",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "alpha", "default_value": 0.1, "description": "alpha"}
+      ]
+    }
+  },
+  {
+    "name": "embedding_lookup",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "embedding_params", "description": "embedding_params"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "partition_strategy", "default_value": "mod", "description": "partition_strategy"}
+      ]
+    }
+  },
+  {
+    "name": "equal",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "exp",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "expand_broadcast",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "shape", "default_value": [], "description": "shape"}
+      ]
+    }
+  },
+  {
+    "name": "expanddims",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "dim", "default_value": 0, "description": "dim"}
+      ]
+    }
+  },
+  {
+    "name": "flatten",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "axis", "default_value": 1, "description": "axis"}
+      ]
+    }
+  },
+  {
+    "name": "floor",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "floor_div",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "fullconnect",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "weight", "description": "weight"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "weights", "default_value": 1, "description": "weights"},
+        {"name": "bias", "default_value": true, "description": "bias"},
+        {"name": "regularize", "default_value": false, "description": "regularize"},
+        {"name": "axis", "default_value": 1, "description": "axis"}
+      ]
+    }
+  },
+  {
+    "name": "fullconnect_op",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "input"},
+        {"name": "in1", "description": "weight"}
+      ],
+      "constants": [
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "weights", "default_value": 1, "description": "weights"},
+        {"name": "bias", "default_value": true, "description": "bias"},
+        {"name": "axis", "default_value": 1, "description": "axis"}
+      ]
+    }
+  },
+  {
+    "name": "gather",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "axis", "default_value": 0, "description": "axis"}
+      ]
+    }
+  },
+  {
+    "name": "gathernd",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "generator_input_layer",
+    "schema": {
+      "category": "Data",
+      "inputs": [],
+      "constants": [],
+      "outputs": [],
+      "attributes": [
+        {"name": "database", "default_value": "", "description": "database"},
+        {"name": "shapes", "default_value": [], "description": "shapes"},
+        {"name": "sparse_tensors", "default_value": [], "description": "sparse_tensors"},
+        {"name": "data_types", "default_value": [], "description": "data_types"}
+      ]
+    }
+  },
+  {
+    "name": "greater",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "greater_equal",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "group_conv1d",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "weight", "description": "weight"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "weights", "default_value": 1, "description": "weights"},
+        {"name": "padding", "default_value": "VALID", "description": "padding"},
+        {"name": "bias", "default_value": true, "description": "bias"},
+        {"name": "group_number", "default_value": 2, "description": "group_number"},
+        {"name": "ksize", "default_value": 1, "description": "ksize"},
+        {"name": "stride", "default_value": 1, "description": "stride"},
+        {"name": "pad", "default_value": [0, 0], "description": "pad"},
+        {"name": "dilation", "default_value": [1, 1, 1], "description": "dilation"}
+      ]
+    }
+  },
+  {
+    "name": "gru",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "input"},
+        {"name": "in1", "description": "in_hstat"}
+      ],
+      "constants": [
+        {"name": "rnn/gru_cell/gates/kernel", "description": "rnn/gru_cell/gates/kernel"},
+        {"name": "rnn/gru_cell/gates/bias", "description": "rnn/gru_cell/gates/bias"},
+        {"name": "rnn/gru_cell/candidate/kernel", "description": "rnn/gru_cell/candidate/kernel"},
+        {"name": "rnn/gru_cell/candidate/bias", "description": "rnn/gru_cell/candidate/bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "output"},
+        {"name": "out1", "description": "out_hstat"}
+      ],
+      "attributes": [
+        {"name": "num_units", "default_value": 1, "description": "num_units"},
+        {"name": "time_major", "default_value": true, "description": "time_major"},
+        {"name": "bias", "default_value": true, "description": "bias"},
+        {"name": "activation", "default_value": "tanh", "description": "activation"},
+        {"name": "recurrent_activation", "default_value": "sigmoid", "description": "recurrent_activation"},
+        {"name": "return_sequences", "default_value": true, "description": "return_sequences"},
+        {"name": "direction", "default_value": "forward", "description": "direction"},
+        {"name": "linear_before_reset", "default_value": 0, "description": "linear_before_reset"}
+      ]
+    }
+  },
+  {
+    "name": "gru_cell",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "data"},
+        {"name": "in1", "description": "hstat"},
+        {"name": "in2", "description": "cond_reset"},
+        {"name": "in3", "description": "cond_update"},
+        {"name": "in4", "description": "cond_candidate"}
+      ],
+      "constants": [
+        {"name": "gates/kernel", "description": "gates/kernel"},
+        {"name": "gates/bias", "description": "gates/bias"},
+        {"name": "candidate/kernel", "description": "candidate/kernel"},
+        {"name": "candidate/bias", "description": "candidate/bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "data"},
+        {"name": "out1", "description": "hstat"}
+      ],
+      "attributes": [
+        {"name": "num_units", "default_value": 1, "description": "num_units"},
+        {"name": "activation", "default_value": "tanh", "description": "activation"},
+        {"name": "recurrent_activation", "default_value": "sigmoid", "description": "recurrent_activation"},
+        {"name": "linear_before_reset", "default_value": 0, "description": "linear_before_reset"},
+        {"name": "cudnn_implementation", "default_value": false, "description": "cudnn_implementation"}
+      ]
+    }
+  },
+  {
+    "name": "gru_keras",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "kernel", "description": "kernel"},
+        {"name": "recurrent_kernel", "description": "recurrent_kernel"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [],
+      "attributes": [
+        {"name": "units", "default_value": 1, "description": "units"},
+        {"name": "activation", "default_value": "tanh", "description": "activation"},
+        {"name": "recurrent_activation", "default_value": "hard_sigmoid", "description": "recurrent_activation"},
+        {"name": "use_bias", "default_value": true, "description": "use_bias"},
+        {"name": "return_sequences", "default_value": false, "description": "return_sequences"},
+        {"name": "return_state", "default_value": false, "description": "return_state"},
+        {"name": "go_backwards", "default_value": false, "description": "go_backwards"},
+        {"name": "stateful", "default_value": false, "description": "stateful"},
+        {"name": "reset_after", "default_value": false, "description": "reset_after"}
+      ]
+    }
+  },
+  {
+    "name": "h5_input_layer",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [],
+      "attributes": [
+        {"name": "database", "default_value": "", "description": "database"},
+        {"name": "shapes", "default_value": [], "description": "shapes"},
+        {"name": "sparse_tensors", "default_value": [], "description": "sparse_tensors"},
+        {"name": "data_types", "default_value": [], "description": "data_types"}
+      ]
+    }
+  },
+  {
+    "name": "hard_swish",
+    "schema": {
+      "category": "Activation",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "image_resize",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "type", "default_value": "bilinear", "description": "type"},
+        {"name": "new_size", "default_value": [], "description": "new_size"},
+        {"name": "align_corners", "default_value": false, "description": "align_corners"},
+        {"name": "half_pixel", "default_value": false, "description": "half_pixel"},
+        {"name": "size_factors", "default_value": null, "description": "size_factors"}
+      ]
+    }
+  },
+  {
+    "name": "image_transform",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "Out0"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "input",
+    "schema": {
+      "category": "Data",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "size", "default_value": "", "description": "size"},
+        {"name": "channels", "default_value": 1, "description": "channels"},
+        {"name": "shape", "default_value": [], "description": "shape"}
+      ]
+    }
+  },
+  {
+    "name": "instancenormalize",
+    "schema": {
+      "category": "Normalization",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "bias", "description": "bias"},
+        {"name": "scale", "description": "scale"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "eps", "default_value": 0.0001, "description": "eps"},
+        {"name": "axis", "default_value": [], "description": "axis"}
+      ]
+    }
+  },
+  {
+    "name": "keras_rnn_lstm",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "kernel", "description": "kernel"},
+        {"name": "recurrent_kernel", "description": "recurrent_kernel"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [],
+      "attributes": [
+        {"name": "cell", "default_value": null, "description": "cell"},
+        {"name": "go_backwards", "default_value": false, "description": "go_backwards"},
+        {"name": "return_sequences", "default_value": false, "description": "return_sequences"},
+        {"name": "return_state", "default_value": false, "description": "return_state"},
+        {"name": "stateful", "default_value": false, "description": "stateful"},
+        {"name": "unroll", "default_value": false, "description": "unroll"}
+      ]
+    }
+  },
+  {
+    "name": "l2normalize",
+    "schema": {
+      "category": "Normalization",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "l2n_dim", "default_value": null, "description": "l2n_dim"},
+        {"name": "eps", "default_value": 1e-12, "description": "eps"}
+      ]
+    }
+  },
+  {
+    "name": "l2normalizescale",
+    "schema": {
+      "category": "Normalization",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "scale", "description": "scale"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "l2n_dim", "default_value": null, "description": "l2n_dim"},
+        {"name": "eps", "default_value": 1e-12, "description": "eps"}
+      ]
+    }
+  },
+  {
+    "name": "l2pooling",
+    "schema": {
+      "category": "Pool",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "padding", "default_value": "VALID", "description": "padding"},
+        {"name": "type", "default_value": "MAX", "description": "type"},
+        {"name": "global_pooling", "default_value": false, "description": "global_pooling"},
+        {"name": "ksize_h", "default_value": 1, "description": "ksize_h"},
+        {"name": "ksize_w", "default_value": 1, "description": "ksize_w"},
+        {"name": "stride_h", "default_value": 1, "description": "stride_h"},
+        {"name": "stride_w", "default_value": 1, "description": "stride_w"},
+        {"name": "pad_h", "default_value": 0, "description": "pad_h"},
+        {"name": "pad_w", "default_value": 0, "description": "pad_w"},
+        {"name": "round_type", "default_value": "ceil", "description": "round_type"},
+        {"name": "pad_method", "default_value": "auto", "description": "pad_method"},
+        {"name": "pad", "default_value": [0, 0, 0, 0], "description": "pad"},
+        {"name": "pad_h_b", "default_value": 0, "description": "pad_h_b"},
+        {"name": "pad_w_r", "default_value": 0, "description": "pad_w_r"}
+      ]
+    }
+  },
+  {
+    "name": "layernormalize",
+    "schema": {
+      "category": "Normalization",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "bias", "description": "bias"},
+        {"name": "scale", "description": "scale"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "eps", "default_value": 0.0001, "description": "eps"}
+      ]
+    }
+  },
+  {
+    "name": "leakyrelu",
+    "schema": {
+      "category": "Activation",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "leaky_ratio", "default_value": 0.1, "description": "leaky_ratio"}
+      ]
+    }
+  },
+  {
+    "name": "less",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "less_equal",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "lmdb_input_layer",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"},
+        {"name": "out1", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "database", "default_value": "", "description": "database"},
+        {"name": "shapes", "default_value": [], "description": "shapes"},
+        {"name": "sparse_tensors", "default_value": [], "description": "sparse_tensors"},
+        {"name": "data_types", "default_value": [], "description": "data_types"}
+      ]
+    }
+  },
+  {
+    "name": "localresponsenormalization",
+    "schema": {
+      "category": "Normalization",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "local_size", "default_value": 1, "description": "local_size"},
+        {"name": "bias", "default_value": 2, "description": "bias"},
+        {"name": "alpha", "default_value": 0.0001, "description": "alpha"},
+        {"name": "beta", "default_value": 0.75, "description": "beta"},
+        {"name": "type", "default_value": "NORM_ACROSS_CHANNELS", "description": "type"}
+      ]
+    }
+  },
+  {
+    "name": "localresponsenormalization_tf",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "local_size", "default_value": 1, "description": "local_size"},
+        {"name": "bias", "default_value": 2, "description": "bias"},
+        {"name": "alpha", "default_value": 0.0001, "description": "alpha"},
+        {"name": "beta", "default_value": 0.75, "description": "beta"},
+        {"name": "type", "default_value": "NORM_ACROSS_CHANNELS", "description": "type"}
+      ]
+    }
+  },
+  {
+    "name": "log",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "log_softmax",
+    "schema": {
+      "category": "Activation",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "sf_axis", "default_value": -1, "description": "sf_axis"}
+      ]
+    }
+  },
+  {
+    "name": "logical_and",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "logical_or",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "lstm",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "data"},
+        {"name": "in1", "description": "hstat"},
+        {"name": "in2", "description": "cstat"}
+      ],
+      "constants": [
+        {"name": "rnn/multi_rnn_cell/cell_0/lstm_cell/kernel", "description": "rnn/multi_rnn_cell/cell_0/lstm_cell/kernel"},
+        {"name": "rnn/multi_rnn_cell/cell_0/lstm_cell/bias", "description": "rnn/multi_rnn_cell/cell_0/lstm_cell/bias"},
+        {"name": "weight_proj", "description": "weight_proj"},
+        {"name": "bias_proj", "description": "bias_proj"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "data"},
+        {"name": "out1", "description": "hstat"},
+        {"name": "out2", "description": "cstat"}
+      ],
+      "attributes": [
+        {"name": "weights", "default_value": 1, "description": "weights"},
+        {"name": "time_major", "default_value": true, "description": "time_major"},
+        {"name": "forget_bias", "default_value": 1, "description": "forget_bias"},
+        {"name": "activation", "default_value": "tanh", "description": "activation"},
+        {"name": "use_cifg", "default_value": false, "description": "use_cifg"},
+        {"name": "use_peepholes", "default_value": false, "description": "use_peepholes"},
+        {"name": "num_proj", "default_value": null, "description": "num_proj"},
+        {"name": "cell_clip", "default_value": 0, "description": "cell_clip"},
+        {"name": "proj_clip", "default_value": 0, "description": "proj_clip"},
+        {"name": "recurrent_activation", "default_value": "sigmoid", "description": "recurrent_activation"},
+        {"name": "return_sequences", "default_value": true, "description": "return_sequences"}
+      ]
+    }
+  },
+  {
+    "name": "lstm_keras",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "kernel", "description": "kernel"},
+        {"name": "recurrent_kernel", "description": "recurrent_kernel"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [],
+      "attributes": [
+        {"name": "units", "default_value": 1, "description": "units"},
+        {"name": "activation", "default_value": "tanh", "description": "activation"},
+        {"name": "recurrent_activation", "default_value": "hard_sigmoid", "description": "recurrent_activation"},
+        {"name": "use_bias", "default_value": true, "description": "use_bias"},
+        {"name": "return_sequences", "default_value": false, "description": "return_sequences"},
+        {"name": "return_state", "default_value": false, "description": "return_state"},
+        {"name": "go_backwards", "default_value": false, "description": "go_backwards"},
+        {"name": "stateful", "default_value": false, "description": "stateful"}
+      ]
+    }
+  },
+  {
+    "name": "lstmunit",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "data"},
+        {"name": "in1", "description": "hstat"},
+        {"name": "in2", "description": "cstat"}
+      ],
+      "constants": [
+        {"name": "wi", "description": "wi"},
+        {"name": "wf", "description": "wf"},
+        {"name": "wc", "description": "wc"},
+        {"name": "wo", "description": "wo"},
+        {"name": "hi", "description": "hi"},
+        {"name": "hf", "description": "hf"},
+        {"name": "hc", "description": "hc"},
+        {"name": "ho", "description": "ho"},
+        {"name": "bi", "description": "bi"},
+        {"name": "bf", "description": "bf"},
+        {"name": "bc", "description": "bc"},
+        {"name": "bo", "description": "bo"},
+        {"name": "wp", "description": "wp"},
+        {"name": "bp", "description": "bp"},
+        {"name": "ln_i", "description": "ln_i"},
+        {"name": "ln_f", "description": "ln_f"},
+        {"name": "ln_c", "description": "ln_c"},
+        {"name": "ln_o", "description": "ln_o"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "data"},
+        {"name": "out1", "description": "hstat"},
+        {"name": "out2", "description": "cstat"}
+      ],
+      "attributes": [
+        {"name": "weights", "default_value": 1, "description": "weights"},
+        {"name": "num_proj", "default_value": null, "description": "num_proj"},
+        {"name": "forget_bias", "default_value": 1, "description": "forget_bias"},
+        {"name": "cell_clip", "default_value": 0, "description": "cell_clip"},
+        {"name": "proj_clip", "default_value": 0, "description": "proj_clip"},
+        {"name": "activation", "default_value": "tanh", "description": "activation"},
+        {"name": "use_layer_norm_lstm", "default_value": false, "description": "use_layer_norm_lstm"},
+        {"name": "use_cifg", "default_value": false, "description": "use_cifg"}
+      ]
+    }
+  },
+  {
+    "name": "margin_loss_layer",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "margin", "default_value": 0.4, "description": "margin"},
+        {"name": "downweight", "default_value": 0.5, "description": "downweight"}
+      ]
+    }
+  },
+  {
+    "name": "mat_inverse",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "adjoint", "default_value": false, "description": "adjoint"}
+      ]
+    }
+  },
+  {
+    "name": "matmul",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in A"},
+        {"name": "in1", "description": "in B"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "Out"}
+      ],
+      "attributes": [
+        {"name": "transpose_a", "default_value": false, "description": "transpose_a"},
+        {"name": "transpose_b", "default_value": false, "description": "transpose_b"}
+      ]
+    }
+  },
+  {
+    "name": "minimum",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "minimum_with_clip",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "clip", "default_value": 1, "description": "clip"}
+      ]
+    }
+  },
+  {
+    "name": "mish",
+    "schema": {
+      "category": "Activation",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "moments",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "mean"},
+        {"name": "out1", "description": "variance"}
+      ],
+      "attributes": [
+        {"name": "axis_list", "default_value": [], "description": "axis_list"},
+        {"name": "keep_dims", "default_value": true, "description": "keep_dims"}
+      ]
+    }
+  },
+  {
+    "name": "multiply",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [
+        {"name": "scale", "description": "scale"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "axis", "default_value": 1, "description": "axis"},
+        {"name": "bias", "default_value": true, "description": "bias"}
+      ]
+    }
+  },
+  {
+    "name": "nce_loss",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [
+        {"name": "weight", "description": "weight"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "num_sampled", "default_value": 1, "description": "num_sampled"},
+        {"name": "num_classes", "default_value": 1, "description": "num_classes"}
+      ]
+    }
+  },
+  {
+    "name": "neg",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "noop",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "noop_multi_out",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [],
+      "attributes": []
+    }
+  },
+  {
+    "name": "norm_with_channel_mean",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "mean", "default_value": [], "description": "mean"}
+      ]
+    }
+  },
+  {
+    "name": "norm_with_min_max",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "min_value", "default_value": 0, "description": "min_value"},
+        {"name": "max_value", "default_value": 1, "description": "max_value"}
+      ]
+    }
+  },
+  {
+    "name": "norm_with_scale",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "scale", "default_value": 1, "description": "scale"}
+      ]
+    }
+  },
+  {
+    "name": "not_equal",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "npy_input_layer",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [],
+      "attributes": [
+        {"name": "database", "default_value": "", "description": "database"},
+        {"name": "shapes", "default_value": [], "description": "shapes"},
+        {"name": "sparse_tensors", "default_value": [], "description": "sparse_tensors"},
+        {"name": "data_types", "default_value": [], "description": "data_types"}
+      ]
+    }
+  },
+  {
+    "name": "output",
+    "schema": {
+      "category": "Data",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "pad",
+    "schema": {
+      "category": "Tensor",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "padding_value", "default_value": [], "description": "padding_value"},
+        {"name": "padding_mode", "default_value": "CONSTANT", "description": "padding_mode"},
+        {"name": "padding_const", "default_value": 0, "description": "padding_const"}
+      ]
+    }
+  },
+  {
+    "name": "permute",
+    "schema": {
+      "category": "Transform",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "perm", "default_value": [0], "description": "perm"}
+      ]
+    }
+  },
+  {
+    "name": "pool3d",
+    "schema": {
+      "category": "Pool",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "type", "default_value": "MAX", "description": "type"},
+        {"name": "global_pooling", "default_value": false, "description": "global_pooling"},
+        {"name": "ksize_d", "default_value": 1, "description": "ksize_d"},
+        {"name": "ksize_h", "default_value": 1, "description": "ksize_h"},
+        {"name": "ksize_w", "default_value": 1, "description": "ksize_w"},
+        {"name": "stride_d", "default_value": 1, "description": "stride_d"},
+        {"name": "stride_h", "default_value": 1, "description": "stride_h"},
+        {"name": "stride_w", "default_value": 1, "description": "stride_w"},
+        {"name": "round_type", "default_value": "ceil", "description": "round_type"},
+        {"name": "pad_method", "default_value": "padding_const", "description": "pad_method"},
+        {"name": "pad", "default_value": [0, 0, 0, 0, 0, 0], "description": "pad"}
+      ]
+    }
+  },
+  {
+    "name": "pooling",
+    "schema": {
+      "category": "Pool",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "padding", "default_value": "VALID", "description": "padding"},
+        {"name": "type", "default_value": "MAX", "description": "type"},
+        {"name": "global_pooling", "default_value": false, "description": "global_pooling"},
+        {"name": "ksize_h", "default_value": 1, "description": "ksize_h"},
+        {"name": "ksize_w", "default_value": 1, "description": "ksize_w"},
+        {"name": "stride_h", "default_value": 1, "description": "stride_h"},
+        {"name": "stride_w", "default_value": 1, "description": "stride_w"},
+        {"name": "pad_h", "default_value": 0, "description": "pad_h"},
+        {"name": "pad_w", "default_value": 0, "description": "pad_w"},
+        {"name": "round_type", "default_value": "ceil", "description": "round_type"},
+        {"name": "pad_method", "default_value": "auto", "description": "pad_method"},
+        {"name": "pad", "default_value": [0, 0, 0, 0], "description": "pad"},
+        {"name": "pad_h_b", "default_value": 0, "description": "pad_h_b"},
+        {"name": "pad_w_r", "default_value": 0, "description": "pad_w_r"}
+      ]
+    }
+  },
+  {
+    "name": "poolwithargmax",
+    "schema": {
+      "category": "Pool",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"},
+        {"name": "out1", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "padding", "default_value": "VALID", "description": "padding"},
+        {"name": "type", "default_value": "MAX", "description": "type"},
+        {"name": "global_pooling", "default_value": false, "description": "global_pooling"},
+        {"name": "ksize_h", "default_value": 1, "description": "ksize_h"},
+        {"name": "ksize_w", "default_value": 1, "description": "ksize_w"},
+        {"name": "stride_h", "default_value": 1, "description": "stride_h"},
+        {"name": "stride_w", "default_value": 1, "description": "stride_w"},
+        {"name": "pad_h", "default_value": 0, "description": "pad_h"},
+        {"name": "pad_w", "default_value": 0, "description": "pad_w"},
+        {"name": "round_type", "default_value": "ceil", "description": "round_type"},
+        {"name": "pad_method", "default_value": "auto", "description": "pad_method"},
+        {"name": "pad", "default_value": [0, 0, 0, 0], "description": "pad"},
+        {"name": "pad_h_b", "default_value": 0, "description": "pad_h_b"},
+        {"name": "pad_w_r", "default_value": 0, "description": "pad_w_r"}
+      ]
+    }
+  },
+  {
+    "name": "postprocess",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "perm", "default_value": [0, 1, 2, 3], "description": "perm"},
+        {"name": "dim_num", "default_value": 4, "description": "dim_num"}
+      ]
+    }
+  },
+  {
+    "name": "pow",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "prelu",
+    "schema": {
+      "category": "Activation",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "a", "description": "a"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "preprocess",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "type", "default_value": "VSI_NN_OP_PRE_PROCESS_RGB", "description": "type"},
+        {"name": "left", "default_value": 0, "description": "left"},
+        {"name": "top", "default_value": 0, "description": "top"},
+        {"name": "width", "default_value": 244, "description": "width"},
+        {"name": "height", "default_value": 224, "description": "height"},
+        {"name": "mean", "default_value": [0, 0, 0], "description": "mean"},
+        {"name": "scale", "default_value": 1, "description": "scale"},
+        {"name": "perm", "default_value": [0, 1, 2, 3], "description": "perm"},
+        {"name": "in_dim_num", "default_value": 4, "description": "in_dim_num"},
+        {"name": "out_dim_num", "default_value": 4, "description": "out_dim_num"},
+        {"name": "out_size", "default_value": [224, 224, 3, 1], "description": "out_size"},
+        {"name": "reverse_channel", "default_value": 1, "description": "reverse_channel"}
+      ]
+    }
+  },
+  {
+    "name": "primary_capsule",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "weight", "description": "weight"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "num_output", "default_value": 1, "description": "num_output"},
+        {"name": "vec_len", "default_value": 1, "description": "vec_len"},
+        {"name": "strides", "default_value": [1, 1], "description": "strides"},
+        {"name": "ksize", "default_value": [1, 1], "description": "ksize"},
+        {"name": "padding", "default_value": "SAME", "description": "padding"}
+      ]
+    }
+  },
+  {
+    "name": "priorbox",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "data"},
+        {"name": "in1", "description": "shape"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "mini_size", "default_value": "", "description": "mini_size"},
+        {"name": "max_size", "default_value": "", "description": "max_size"},
+        {"name": "aspect_ratio", "default_value": "", "description": "aspect_ratio"},
+        {"name": "flip", "default_value": "", "description": "flip"},
+        {"name": "clip", "default_value": "", "description": "clip"},
+        {"name": "variance", "default_value": "0.1", "description": "variance"},
+        {"name": "image_size", "default_value": 0, "description": "image_size"},
+        {"name": "image_h", "default_value": 0, "description": "image_h"},
+        {"name": "image_w", "default_value": 0, "description": "image_w"},
+        {"name": "step", "default_value": 0, "description": "step"},
+        {"name": "step_h", "default_value": 0, "description": "step_h"},
+        {"name": "step_w", "default_value": 0, "description": "step_w"},
+        {"name": "offset", "default_value": 0.5, "description": "offset"}
+      ]
+    }
+  },
+  {
+    "name": "proposal",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "input"},
+        {"name": "in1", "description": "input"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"},
+        {"name": "out1", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "feat_stride", "default_value": 16, "description": "feat_stride"},
+        {"name": "anchor_scales", "default_value": "8 16 32", "description": "anchor_scales"},
+        {"name": "anchor_ratios", "default_value": "0.5 1 2", "description": "anchor_ratios"},
+        {"name": "anchor_base_size", "default_value": 16, "description": "anchor_base_size"},
+        {"name": "pre_nms_top_n", "default_value": 6000, "description": "pre_nms_top_n"},
+        {"name": "post_nms_top_n", "default_value": 300, "description": "post_nms_top_n"},
+        {"name": "nms_thresh", "default_value": 0.7, "description": "nms_thresh"},
+        {"name": "min_size", "default_value": 16, "description": "min_size"},
+        {"name": "im_info", "default_value": "800 600 1 1", "description": "im_info"},
+        {"name": "has_bg", "default_value": true, "description": "has_bg"},
+        {"name": "dynamic", "default_value": false, "description": "dynamic"}
+      ]
+    }
+  },
+  {
+    "name": "quantize",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "real_div",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "reconstruction_loss",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "balance_factor", "default_value": 0.0005, "description": "balance_factor"}
+      ]
+    }
+  },
+  {
+    "name": "recurrent",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "reducemax",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "axis_list", "default_value": null, "description": "axis_list"},
+        {"name": "keep_dims", "default_value": false, "description": "keep_dims"}
+      ]
+    }
+  },
+  {
+    "name": "reducemean",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "axis_list", "default_value": null, "description": "axis_list"},
+        {"name": "keep_dims", "default_value": false, "description": "keep_dims"}
+      ]
+    }
+  },
+  {
+    "name": "reducemin",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "axis_list", "default_value": null, "description": "axis_list"},
+        {"name": "keep_dims", "default_value": false, "description": "keep_dims"}
+      ]
+    }
+  },
+  {
+    "name": "reducesum",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "axis_list", "default_value": [], "description": "axis_list"},
+        {"name": "keep_dims", "default_value": false, "description": "keep_dims"}
+      ]
+    }
+  },
+  {
+    "name": "region",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "relu",
+    "schema": {
+      "category": "Activation",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "relu_keras",
+    "schema": {
+      "category": "Activation",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "alpha", "default_value": 0, "description": "alpha"},
+        {"name": "max_value", "default_value": "inf", "description": "max_value"},
+        {"name": "threshold", "default_value": 0, "description": "threshold"}
+      ]
+    }
+  },
+  {
+    "name": "relun",
+    "schema": {
+      "category": "Activation",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "relu_clamp_top", "default_value": "inf", "description": "relu_clamp_top"},
+        {"name": "relu_clamp_bottom", "default_value": "0", "description": "relu_clamp_bottom"}
+      ]
+    }
+  },
+  {
+    "name": "reorg",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "stride", "default_value": 2, "description": "stride"}
+      ]
+    }
+  },
+  {
+    "name": "reshape",
+    "schema": {
+      "category": "Shape",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "shape", "default_value": [], "description": "shape"}
+      ]
+    }
+  },
+  {
+    "name": "resizebilinear_image",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "new_size", "default_value": [], "description": "new_size"},
+        {"name": "align_corners", "default_value": false, "description": "align_corners"}
+      ]
+    }
+  },
+  {
+    "name": "resizenearest_image",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "new_size", "default_value": [], "description": "new_size"},
+        {"name": "align_corners", "default_value": false, "description": "align_corners"}
+      ]
+    }
+  },
+  {
+    "name": "reverse",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "axis", "default_value": [], "description": "axis"}
+      ]
+    }
+  },
+  {
+    "name": "reverse_sequence",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "seq_lengths"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "seq_axis", "default_value": 1, "description": "seq_axis"},
+        {"name": "batch_axis", "default_value": 2, "description": "batch_axis"}
+      ]
+    }
+  },
+  {
+    "name": "roipooling",
+    "schema": {
+      "category": "Pool",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "pooled_h", "default_value": 6, "description": "pooled_h"},
+        {"name": "pooled_w", "default_value": 6, "description": "pooled_w"},
+        {"name": "spatial_scale", "default_value": 0.0625, "description": "spatial_scale"},
+        {"name": "sampling_ratio", "default_value": 0, "description": "sampling_ratio"}
+      ]
+    }
+  },
+  {
+    "name": "route_train",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "rsqrt",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "scatternd",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "shape", "default_value": [], "description": "shape"}
+      ]
+    }
+  },
+  {
+    "name": "shuffle",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "group_number", "default_value": 1, "description": "group_number"}
+      ]
+    }
+  },
+  {
+    "name": "sigmoid",
+    "schema": {
+      "category": "Activation",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "signalframe",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "frame_length", "default_value": 0, "description": "frame_length"},
+        {"name": "frame_step", "default_value": 0, "description": "frame_step"},
+        {"name": "pad_end", "default_value": false, "description": "pad_end"},
+        {"name": "pad_value", "default_value": 0, "description": "pad_value"},
+        {"name": "axis", "default_value": -1, "description": "axis"}
+      ]
+    }
+  },
+  {
+    "name": "simplernn_keras",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "kernel", "description": "kernel"},
+        {"name": "recurrent_kernel", "description": "recurrent_kernel"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [],
+      "attributes": [
+        {"name": "units", "default_value": 1, "description": "units"},
+        {"name": "activation", "default_value": "tanh", "description": "activation"},
+        {"name": "use_bias", "default_value": true, "description": "use_bias"},
+        {"name": "return_sequences", "default_value": false, "description": "return_sequences"},
+        {"name": "return_state", "default_value": false, "description": "return_state"},
+        {"name": "go_backwards", "default_value": false, "description": "go_backwards"},
+        {"name": "stateful", "default_value": false, "description": "stateful"}
+      ]
+    }
+  },
+  {
+    "name": "sin",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "slice",
+    "schema": {
+      "category": "Tensor",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "begin", "default_value": [], "description": "begin"},
+        {"name": "size", "default_value": [], "description": "size"}
+      ]
+    }
+  },
+  {
+    "name": "softmax",
+    "schema": {
+      "category": "Activation",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "sf_axis", "default_value": -1, "description": "sf_axis"},
+        {"name": "beta", "default_value": 1, "description": "beta"}
+      ]
+    }
+  },
+  {
+    "name": "softmax_with_logits_loss_layer",
+    "schema": {
+      "category": "Activation",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "softrelu",
+    "schema": {
+      "category": "Activation",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "space2batch",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "block_shape", "default_value": [2, 2], "description": "block_shape"},
+        {"name": "block_paddings", "default_value": [
+          [0, 0],
+          [0, 0]
+        ], "description": "block_paddings"}
+      ]
+    }
+  },
+  {
+    "name": "space2depth",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "block_size", "default_value": [], "description": "block_size"}
+      ]
+    }
+  },
+  {
+    "name": "split",
+    "schema": {
+      "category": "Tensor",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [],
+      "attributes": [
+        {"name": "dim", "default_value": 1, "description": "dim"},
+        {"name": "slices", "default_value": "", "description": "slices"},
+        {"name": "slices_tf", "default_value": "", "description": "slices_tf"},
+        {"name": "unstack", "default_value": false, "description": "unstack"}
+      ]
+    }
+  },
+  {
+    "name": "sqlite_input_layer",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"},
+        {"name": "out1", "description": "out"},
+        {"name": "out2", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "database", "default_value": "", "description": "database"},
+        {"name": "shapes", "default_value": [], "description": "shapes"},
+        {"name": "sparse_tensors", "default_value": [], "description": "sparse_tensors"},
+        {"name": "data_types", "default_value": [], "description": "data_types"}
+      ]
+    }
+  },
+  {
+    "name": "sqrt",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "square",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "squashing",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "squeeze",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "axis_list", "default_value": null, "description": "axis_list"},
+        {"name": "name", "default_value": null, "description": "name"}
+      ]
+    }
+  },
+  {
+    "name": "stack",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "axis", "default_value": 0, "description": "axis"}
+      ]
+    }
+  },
+  {
+    "name": "stack_concat",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"},
+        {"name": "in2", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "shape", "default_value": [1, 32, 256], "description": "shape"},
+        {"name": "axis", "default_value": 1, "description": "axis"}
+      ]
+    }
+  },
+  {
+    "name": "stridedslice",
+    "schema": {
+      "category": "Tensor",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "slice_begin_mask", "default_value": 0, "description": "slice_begin_mask"},
+        {"name": "slice_end_mask", "default_value": 0, "description": "slice_end_mask"},
+        {"name": "slice_ellipsis_mask", "default_value": 0, "description": "slice_ellipsis_mask"},
+        {"name": "slice_new_axis_mask", "default_value": 0, "description": "slice_new_axis_mask"},
+        {"name": "slice_shrink_axis_mask", "default_value": 0, "description": "slice_shrink_axis_mask"},
+        {"name": "slice_begin", "default_value": [0, 0, 0, 0], "description": "slice_begin"},
+        {"name": "slice_end", "default_value": [-1, -1, -1, -1], "description": "slice_end"},
+        {"name": "slice_strides", "default_value": [1, 1, 1, 1], "description": "slice_strides"}
+      ]
+    }
+  },
+  {
+    "name": "subgraph",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [],
+      "attributes": [
+        {"name": "sg_argv", "default_value": "", "description": "sg_argv"},
+        {"name": "sg_func", "default_value": "", "description": "sg_func"},
+        {"name": "sg_out_shapes", "default_value": "", "description": "sg_out_shapes"},
+        {"name": "sg_graph_buffer", "default_value": "", "description": "sg_graph_buffer"},
+        {"name": "sg_input_nodes", "default_value": "", "description": "sg_input_nodes"},
+        {"name": "sg_output_nodes", "default_value": "", "description": "sg_output_nodes"}
+      ]
+    }
+  },
+  {
+    "name": "subtract",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "minuend"},
+        {"name": "in1", "description": "subtrahend"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "svdf",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [
+        {"name": "weights_feature", "description": "weights_feature"},
+        {"name": "weights_time", "description": "weights_time"},
+        {"name": "bias", "description": "bias"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "rank", "default_value": 1, "description": "rank"},
+        {"name": "num_units", "default_value": 1, "description": "num_units"},
+        {"name": "spectrogram_length", "default_value": 1, "description": "spectrogram_length"}
+      ]
+    }
+  },
+  {
+    "name": "swish",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "tanh",
+    "schema": {
+      "category": "Activation",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "hyperbolic_tan_scale_a", "default_value": 1, "description": "hyperbolic_tan_scale_a"},
+        {"name": "hyperbolic_tan_scale_b", "default_value": 1, "description": "hyperbolic_tan_scale_b"}
+      ]
+    }
+  },
+  {
+    "name": "text_input_layer",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [],
+      "attributes": [
+        {"name": "database", "default_value": "", "description": "database"},
+        {"name": "shapes", "default_value": [], "description": "shapes"},
+        {"name": "sparse_tensors", "default_value": [], "description": "sparse_tensors"},
+        {"name": "data_types", "default_value": [], "description": "data_types"}
+      ]
+    }
+  },
+  {
+    "name": "tile",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "multiples", "default_value": [], "description": "multiples"}
+      ]
+    }
+  },
+  {
+    "name": "topk",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "topk", "default_value": 1, "description": "topk"}
+      ]
+    }
+  },
+  {
+    "name": "topk_score",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"},
+        {"name": "out1", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "topk", "default_value": 1, "description": "topk"}
+      ]
+    }
+  },
+  {
+    "name": "unstack",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [],
+      "attributes": [
+        {"name": "axis", "default_value": 1, "description": "axis"}
+      ]
+    }
+  },
+  {
+    "name": "upsampling",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "factor", "default_value": 2, "description": "factor"}
+      ]
+    }
+  },
+  {
+    "name": "variable",
+    "schema": {
+      "category": "Data",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [
+        {"name": "data", "description": "data"}
+      ],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "shape", "default_value": [1], "description": "shape"}
+      ]
+    }
+  },
+  {
+    "name": "where",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"},
+        {"name": "in1", "description": "in"},
+        {"name": "in2", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "word2vec_input",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"},
+        {"name": "out1", "description": "out"}
+      ],
+      "attributes": [
+        {"name": "database", "default_value": "", "description": "database"},
+        {"name": "shapes", "default_value": [], "description": "shapes"},
+        {"name": "sparse_tensors", "default_value": [], "description": "sparse_tensors"},
+        {"name": "data_types", "default_value": [], "description": "data_types"},
+        {"name": "dictionary", "default_value": "", "description": "dictionary"},
+        {"name": "model", "default_value": "skip-gram", "description": "model"},
+        {"name": "num_skips", "default_value": 2, "description": "num_skips"},
+        {"name": "skip_window", "default_value": 1, "description": "skip_window"}
+      ]
+    }
+  },
+  {
+    "name": "yolo",
+    "schema": {
+      "category": "Layer",
+      "inputs": [
+        {"name": "in0", "description": "in"}
+      ],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  },
+  {
+    "name": "yoloprocess",
+    "schema": {
+      "category": "Layer",
+      "inputs": [],
+      "constants": [],
+      "outputs": [
+        {"name": "out0", "description": "out"}
+      ],
+      "attributes": []
+    }
+  }
+]

--- a/source/acuity.js
+++ b/source/acuity.js
@@ -1,0 +1,715 @@
+/* jshint esversion: 6 */
+/* eslint "indent": [ "error", 4, { "SwitchCase": 1 } ] */
+
+var acuity = acuity || {};
+var json = json || require('./json');
+
+acuity.ModelFactory = class {
+
+    match(context) {
+        const extension = context.identifier.split('.').pop().toLowerCase();
+        if (extension === 'json') {
+            const tags = context.tags('json');
+            if (tags.has('MetaData') && tags.has('Layers')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    open(context, host) {
+        return acuity.Metadata.open(host).then((metadata) => {
+            const extension = context.identifier.split('.').pop().toLowerCase();
+            switch (extension) {
+                case 'json': {
+                    const buffer = context.stream.peek();
+                    const reader = json.TextReader.create(buffer);
+                    const model = reader.read();
+                    if (model && model.MetaData && model.Layers) {
+                        return new acuity.Model(metadata, model);
+                    }
+                }
+            }
+        });
+    }
+};
+
+acuity.Model = class {
+
+    constructor(metadata, model, data, quantization) {
+        this._graphs = [];
+        this._name = model.MetaData.Name;
+        this._format = 'Acuity ' + 'v' + model.MetaData.AcuityVersion;
+        this._version = model.MetaData.AcuityVersion;
+        this._graphs.push(new acuity.Graph(metadata, model, data, quantization));
+    }
+
+    get format() {
+        return this._format;
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    get version() {
+        return this._version;
+    }
+
+    get graphs() {
+        return this._graphs;
+    }
+};
+
+acuity.Graph = class {
+
+    constructor(metadata, model) {
+        this._nodes = [];
+        this._inputs = [];
+        this._outputs = [];
+        const args = new Map();
+
+        for (const layerName of Object.keys(model.Layers)) {
+            const layer = model.Layers[layerName];
+            for (const port of layer.outputs) {
+                let shape = null;
+                if (layer.op.toLowerCase() == 'input' ||
+                    layer.op.toLowerCase() == 'variable') {
+                    if (Object.prototype.hasOwnProperty.call(layer.parameters, 'shape')) {
+                        shape = layer.parameters.shape;
+                    }
+                    else if (Object.prototype.hasOwnProperty.call(layer.parameters, 'size') &&
+                            Object.prototype.hasOwnProperty.call(layer.parameters, 'channels')) {
+                        const sizes = layer.parameters.size.split(' ');
+                        shape = [0, parseInt(sizes[0]), parseInt(sizes[1]), layer.parameters.channels];
+                    }
+                }
+                const portUrl = acuity.Utility.getTensorUrl(layerName, port);
+                const tensorType = new acuity.TensorType(null, new acuity.TensorShape(shape));
+                const arg = new acuity.Argument(portUrl, tensorType, null, null);
+                args.set(portUrl, arg);
+            }
+        }
+
+        for (const layerName of Object.keys(model.Layers)) {
+            const layer = model.Layers[layerName];
+            if (layer.op.toLowerCase() == 'input') {
+                this._inputs.push(new acuity.Parameter(layerName, true,
+                    [args.get(acuity.Utility.getTensorUrl(layerName, layer.outputs[0]))]));
+            }
+            else if (layer.op.toLowerCase() == 'output') {
+                this._outputs.push(new acuity.Parameter(layerName, true,
+                    [args.get(layer.inputs[0])]));
+            }
+            else {
+                const schema = metadata.type(layer.op);
+                this._nodes.push(new acuity.Node(schema, layerName, layer, args));
+            }
+        }
+
+        new acuity.ShapeInference(this).process();
+    }
+
+    get inputs() {
+        return this._inputs;
+    }
+
+    get outputs() {
+        return this._outputs;
+    }
+
+    get nodes() {
+        return this._nodes;
+    }
+};
+
+acuity.Node = class {
+
+    constructor(schema, name, layer, args) {
+        this._schema = schema;
+        this._name = name;
+        this._type = layer.op;
+        this._inputs = [];
+        this._constants = [];
+        this._outputs = [];
+        this._attributes = [];
+        this._layer = layer;
+
+        if (this._schema) {
+            for (const attr of this._schema.attributes) {
+                if (Object.prototype.hasOwnProperty.call(layer.parameters, attr.name)) {
+                    this._attributes.push(new acuity.Attribute(attr.name, layer.parameters[attr.name]));
+                }
+                else {
+                    this._attributes.push(new acuity.Attribute(attr.name, attr.default_value + ' (default)'));
+                }
+            }
+
+            if (Object.prototype.hasOwnProperty.call(this._schema, 'constants')) {
+                for (const constant of this._schema.constants) {
+                    const tensorUrl = acuity.Utility.getTensorUrl(name, constant.name);
+                    const tensorType = new acuity.TensorType(null, new acuity.TensorShape(), true);
+                    args.set(tensorUrl, new acuity.Argument(tensorUrl, tensorType, null, null));
+                    this._constants.push(constant);
+                }
+            }
+        }
+
+        for (let i = 0; i < layer.inputs.length; i++) {
+            const portName = "in" + i;
+            const port = layer.inputs[i];
+            const arg = args.get(port);
+            this._inputs.push(new acuity.Parameter(portName, true, [arg]));
+        }
+
+        for (const constant of this._constants) {
+            const tensorUrl = acuity.Utility.getTensorUrl(name, constant.name);
+            const arg = args.get(tensorUrl);
+            this._inputs.push(new acuity.Parameter(constant.name, true, [arg]));
+        }
+
+        for (const port of layer.outputs) {
+            const portUrl = acuity.Utility.getTensorUrl(name, port);
+            const arg = args.get(portUrl);
+            this._outputs.push(new acuity.Parameter(port, true, [arg]));
+        }
+    }
+
+    get type() {
+        return this._type;
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    get metadata() {
+        return this._schema;
+    }
+
+    get inputs() {
+        return this._inputs;
+    }
+
+    get outputs() {
+        return this._outputs;
+    }
+
+    get attributes() {
+        return this._attributes;
+    }
+
+    computeOutputShape(func) {
+        let inputShapeReady = true;
+        for (const input of this.inputs) {
+            if (!input.arguments[0].type.isConst && !input.arguments[0].type.shape.isShapeReady()) {
+                inputShapeReady = false;
+            }
+        }
+
+        if (inputShapeReady) {
+            const parameters = this._layer.parameters;
+            const inputsShapes = [];
+            for (const input of this.inputs) {
+                inputsShapes.push(input.arguments[0].type.shape.dimensions);
+            }
+
+            const outputsShape = func(inputsShapes, parameters);
+            const outputLength = Math.min(outputsShape.length, this.outputs.length);
+            for (let i = 0; i < outputLength; i++) {
+                this.outputs[i].arguments[0].type.shape.dimensions = outputsShape[i];
+            }
+        }
+    }
+};
+
+acuity.Attribute = class {
+
+    constructor(name, value) {
+        this._type = null;
+        this._name = name;
+        this._value = value;
+        this._visible = true;
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    get type() {
+        return this._type;
+    }
+
+    get value() {
+        return this._value;
+    }
+
+    get visible() {
+        return this._visible == false ? false : true;
+    }
+};
+
+acuity.Parameter = class {
+
+    constructor(name, visible, args) {
+        this._name = name;
+        this._visible = visible;
+        this._arguments = args;
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    get visible() {
+        return this._visible;
+    }
+
+    get arguments() {
+        return this._arguments;
+    }
+};
+
+acuity.Argument = class {
+
+    constructor(name, type, quantization, initializer) {
+        if (typeof name !== 'string') {
+            throw new acuity.Error("Invalid argument identifier '" + JSON.stringify(name) + "'.");
+        }
+        this._name = name;
+        this._type = type || null;
+        this._quantization = quantization || null;
+        this._initializer = initializer || null;
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    get type() {
+        return this._type;
+    }
+
+    get quantization() {
+        return this._quantization;
+    }
+
+    set quantization(quantization) {
+        this._quantization = quantization;
+    }
+
+    get initializer() {
+        return this._initializer;
+    }
+
+    set initializer(initializer) {
+        this._initializer = initializer;
+    }
+};
+
+acuity.TensorType = class {
+
+    constructor(dataType, shape, is_const) {
+        this._dataType = dataType || 'float32';
+        this._shape = shape;
+        this._is_const = is_const || false;
+    }
+
+    get isConst() {
+        return this._is_const;
+    }
+
+    get dataType() {
+        return this._dataType;
+    }
+
+    set dataType(dataType) {
+        this._dataType = dataType;
+    }
+
+    get shape() {
+        return this._shape;
+    }
+
+    set shape(shape) {
+        this._shape = shape;
+    }
+
+    set denotation(value) {
+        this._denotation = value;
+    }
+
+    get denotation() {
+        return this._denotation;
+    }
+
+    toString() {
+        return (this.dataType || '?') + this._shape.toString();
+    }
+};
+
+acuity.TensorShape = class {
+
+    constructor(dimensions) {
+        this._dimensions = dimensions;
+        this._shapeReady = this._dimensions && this._dimensions.length > 0;
+    }
+
+    get dimensions() {
+        return this._dimensions;
+    }
+
+    set dimensions(dimensions) {
+        this._dimensions = dimensions;
+        this._shapeReady = this._dimensions && this._dimensions.length > 0;
+    }
+
+    isShapeReady() {
+        return this._shapeReady;
+    }
+
+    toString() {
+        if (!this._dimensions || this._dimensions.length == 0) {
+            return '';
+        }
+        return '[' + this._dimensions.map((dimension) => dimension.toString()).join(',') + ']';
+    }
+};
+
+acuity.Metadata = class {
+
+    static open(host) {
+        if (acuity.Metadata._metadata) {
+            return Promise.resolve(acuity.Metadata._metadata);
+        }
+        return host.request(null, 'acuity-metadata.json', 'utf-8').then((data) => {
+            acuity.Metadata._metadata = new acuity.Metadata(data);
+            return acuity.Metadata._metadata;
+        }).catch(() => {
+            acuity.Metadata._metadata = new acuity.Metadata(null);
+            return acuity.Metadata._metadata;
+        });
+    }
+
+    constructor(data) {
+        this._map = new Map();
+        if (data) {
+            const items = JSON.parse(data);
+            if (items) {
+                for (const item of items) {
+                    item.schema.name = item.name;
+                    this._map.set(item.name, item.schema);
+                }
+            }
+        }
+    }
+
+    type(name) {
+        return this._map.has(name) ? this._map.get(name) : null;
+    }
+
+    attribute(type, name) {
+        const schema = this.type(type);
+        if (schema) {
+            let attributeMap = schema.attributeMap;
+            if (!attributeMap) {
+                attributeMap = {};
+                if (schema.attributes) {
+                    for (const attribute of schema.attributes) {
+                        attributeMap[attribute.name] = attribute;
+                    }
+                }
+                schema.attributeMap = attributeMap;
+            }
+            const attributeSchema = attributeMap[name];
+            if (attributeSchema) {
+                return attributeSchema;
+            }
+        }
+        return null;
+    }
+};
+
+acuity.ShapeInference =  class {
+
+    constructor(graph) {
+        this._graph = graph;
+        this._tensorProducerMap = new Map();
+        for (const node of this._graph.nodes) {
+            for (const output of node.outputs) {
+                const tensorUrl = acuity.Utility.getTensorUrl(node.name, output.name);
+                this._tensorProducerMap.set(tensorUrl, node);
+            }
+        }
+        this._computeOutputShapeFuncs = new acuity.ComputeOutputShapeFuncs();
+    }
+
+    process() {
+        for (const ouput of this._graph.outputs) {
+            this._shapeInference(ouput);
+        }
+    }
+
+    _shapeInference(output) {
+        const tensorName = output.arguments[0].name;
+        if (this._tensorProducerMap.has(tensorName)) {
+            let inputShapeReady = true;
+            const producer = this._tensorProducerMap.get(tensorName);
+            for (const input of producer.inputs) {
+                if (!input.arguments[0].type.isConst && !input.arguments[0].type.shape.isShapeReady()) {
+                    this._shapeInference(input);
+                    if (!input.arguments[0].type.shape.isShapeReady()) {
+                        inputShapeReady = false;
+                        break;
+                    }
+                }
+            }
+
+            if (inputShapeReady) {
+                producer.computeOutputShape(this._computeOutputShapeFuncs.get(producer.type));
+            }
+        }
+        else {
+            //throw new acuity.Error("Unknown tensor '" + tensorName + "'.");
+        }
+    }
+};
+
+acuity.ComputeOutputShapeFuncs = class {
+    constructor() {
+        this._no_shape_changed = function(inputsShapes, parameters) {
+            return [inputsShapes[0].slice()];
+        };
+
+        this._registry = new Map();
+        this._registry['a_times_b_plus_c'] = this._no_shape_changed;
+        this._registry['abs'] = this._no_shape_changed;
+        this._registry['add'] = function(inputsShapes, parameters) { return []; };
+        this._registry['addn'] = function(inputsShapes, parameters) { return []; };
+        this._registry['argmin'] = function(inputsShapes, parameters) { return []; };
+        //this._registry['base_input_layer'] = function(inputsShapes, parameters) { return []; };
+        this._registry['batch2space'] = function(inputsShapes, parameters) { return []; };
+        this._registry['batchnorm_single'] = function(inputsShapes, parameters) { return []; };
+        this._registry['batchnormalize'] = function(inputsShapes, parameters) { return []; };
+        this._registry['capsule_norm'] = function(inputsShapes, parameters) { return []; };
+        this._registry['cast'] = this._no_shape_changed;
+        this._registry['clipbyvalue'] = this._no_shape_changed;
+        this._registry['concat'] = function(inputsShapes, parameters) {
+            const outputShape = inputsShapes[0].slice();
+            outputShape[parameters.dim] = 0;
+            for (const shape of inputsShapes) {
+                outputShape[parameters.dim] += shape[parameters.dim];
+            }
+            return [outputShape];
+        };
+        this._registry['concatshift'] = function(inputsShapes, parameters) { return []; };
+        this._registry['continuationindicator'] = function(inputsShapes, parameters) { return []; };
+        this._registry['conv1d'] = function(inputsShapes, parameters) { return []; };
+        this._registry['conv2d_op'] = function(inputsShapes, parameters) { return []; };
+        this._registry['conv3d'] = function(inputsShapes, parameters) { return []; };
+        this._registry['convolution'] = function(inputsShapes, parameters) {
+            if (parameters.padding == 'VALID') {
+                const out_h = ~~((inputsShapes[0][1] + parameters.stride_h - parameters.ksize_h) / parameters.stride_h);
+                const out_w = ~~((inputsShapes[0][2] + parameters.stride_w - parameters.ksize_w) / parameters.stride_w);
+                return [[inputsShapes[0][0], out_h, out_w, parameters.weights]];
+            }
+            else if (parameters.padding == 'SAME') {
+                const out_h = ~~((inputsShapes[0][1] + parameters.stride_h - 1) / parameters.stride_h);
+                const out_w = ~~((inputsShapes[0][2] + parameters.stride_w - 1) / parameters.stride_w);
+                return [[inputsShapes[0][0], out_h, out_w, parameters.weights]];
+            }
+        };
+        this._registry['crop_image'] = function(inputsShapes, parameters) { return []; };
+        this._registry['cropandresize'] = function(inputsShapes, parameters) { return []; };
+        this._registry['ctc_loss_layer'] = function(inputsShapes, parameters) { return []; };
+        this._registry['customlayer'] = function(inputsShapes, parameters) { return []; };
+        this._registry['deconvolution'] = function(inputsShapes, parameters) { return []; };
+        this._registry['depth2space'] = function(inputsShapes, parameters) { return []; };
+        this._registry['depthwise_conv1d'] = function(inputsShapes, parameters) { return []; };
+        this._registry['depthwise_conv2d_op'] = function(inputsShapes, parameters) { return []; };
+        this._registry['depthwise_convolution'] = function(inputsShapes, parameters) { return []; };
+        this._registry['dequantize'] = this._no_shape_changed;
+        this._registry['detectionevaluate'] = function(inputsShapes, parameters) { return []; };
+        this._registry['detectionoutput'] = function(inputsShapes, parameters) { return []; };
+        this._registry['digit_capsule'] = function(inputsShapes, parameters) { return []; };
+        this._registry['divide'] = function(inputsShapes, parameters) { return []; };
+        this._registry['dropout'] = function(inputsShapes, parameters) { return []; };
+        this._registry['dtype_converter'] = this._no_shape_changed;
+        this._registry['eltwise'] = function(inputsShapes, parameters) { return []; };
+        this._registry['elu'] = this._no_shape_changed;
+        this._registry['embedding_lookup'] = function(inputsShapes, parameters) { return []; };
+        this._registry['equal'] = function(inputsShapes, parameters) { return []; };
+        this._registry['exp'] = this._no_shape_changed;
+        this._registry['expand_broadcast'] = function(inputsShapes, parameters) { return []; };
+        this._registry['expanddims'] = function(inputsShapes, parameters) { return []; };
+        this._registry['flatten'] = function(inputsShapes, parameters) { return []; };
+        this._registry['floor'] = this._no_shape_changed;
+        this._registry['floor_div'] = this._no_shape_changed;
+        this._registry['fullconnect'] = function(inputsShapes, parameters) {
+            return [inputsShapes[0].slice(0, parameters.axis).concat([parameters.weights])];
+        };
+        this._registry['fullconnect_op'] = function(inputsShapes, parameters) { return []; };
+        this._registry['gather'] = function(inputsShapes, parameters) { return []; };
+        this._registry['gathernd'] = function(inputsShapes, parameters) { return []; };
+        this._registry['generator_input_layer'] = function(inputsShapes, parameters) { return []; };
+        this._registry['greater'] = function(inputsShapes, parameters) { return []; };
+        this._registry['greater_equal'] = function(inputsShapes, parameters) { return []; };
+        this._registry['group_conv1d'] = function(inputsShapes, parameters) { return []; };
+        this._registry['gru'] = function(inputsShapes, parameters) { return []; };
+        this._registry['gru_cell'] = function(inputsShapes, parameters) { return []; };
+        this._registry['gru_keras'] = function(inputsShapes, parameters) { return []; };
+        //this._registry['h5_input_layer'] = function(inputsShapes, parameters) { return []; };
+        this._registry['hard_swish'] = this._no_shape_changed;
+        this._registry['image_resize'] = function(inputsShapes, parameters) { return []; };
+        this._registry['image_transform'] = function(inputsShapes, parameters) { return []; };
+        //this._registry['input'] = function(inputsShapes, parameters) { return []; };
+        this._registry['instancenormalize'] = function(inputsShapes, parameters) { return []; };
+        this._registry['keras_rnn_lstm'] = function(inputsShapes, parameters) { return []; };
+        this._registry['l2normalize'] = function(inputsShapes, parameters) { return []; };
+        this._registry['l2normalizescale'] = function(inputsShapes, parameters) { return []; };
+        this._registry['l2pooling'] = function(inputsShapes, parameters) { return []; };
+        this._registry['layernormalize'] = function(inputsShapes, parameters) { return []; };
+        this._registry['leakyrelu'] = this._no_shape_changed;
+        this._registry['less'] = function(inputsShapes, parameters) { return []; };
+        this._registry['less_equal'] = function(inputsShapes, parameters) { return []; };
+        this._registry['lmdb_input_layer'] = function(inputsShapes, parameters) { return []; };
+        this._registry['localresponsenormalization'] = function(inputsShapes, parameters) { return []; };
+        this._registry['localresponsenormalization_tf'] = function(inputsShapes, parameters) { return []; };
+        this._registry['log'] = this._no_shape_changed;
+        this._registry['log_softmax'] = this._no_shape_changed;
+        this._registry['logical_and'] = function(inputsShapes, parameters) { return []; };
+        this._registry['logical_or'] = function(inputsShapes, parameters) { return []; };
+        this._registry['lstm'] = function(inputsShapes, parameters) { return []; };
+        this._registry['lstm_keras'] = function(inputsShapes, parameters) { return []; };
+        this._registry['lstmunit'] = function(inputsShapes, parameters) { return []; };
+        this._registry['margin_loss_layer'] = function(inputsShapes, parameters) { return []; };
+        this._registry['mat_inverse'] = function(inputsShapes, parameters) { return []; };
+        this._registry['matmul'] = function(inputsShapes, parameters) { return []; };
+        this._registry['minimum'] = function(inputsShapes, parameters) { return []; };
+        this._registry['minimum_with_clip'] = function(inputsShapes, parameters) { return []; };
+        this._registry['mish'] = function(inputsShapes, parameters) { return []; };
+        this._registry['moments'] = function(inputsShapes, parameters) { return []; };
+        this._registry['multiply'] = function(inputsShapes, parameters) { return []; };
+        this._registry['nce_loss'] = function(inputsShapes, parameters) { return []; };
+        this._registry['neg'] = this._no_shape_changed;
+        this._registry['noop'] = function(inputsShapes, parameters) { return []; };
+        this._registry['noop_multi_out'] = function(inputsShapes, parameters) { return []; };
+        this._registry['norm_with_channel_mean'] = function(inputsShapes, parameters) { return []; };
+        this._registry['norm_with_min_max'] = function(inputsShapes, parameters) { return []; };
+        this._registry['norm_with_scale'] = function(inputsShapes, parameters) { return []; };
+        this._registry['not_equal'] = function(inputsShapes, parameters) { return []; };
+        this._registry['npy_input_layer'] = function(inputsShapes, parameters) { return []; };
+        //this._registry['output'] = function(inputsShapes, parameters) { return []; };
+        this._registry['pad'] = function(inputsShapes, parameters) { return []; };
+        this._registry['permute'] = function(inputsShapes, parameters) { return []; };
+        this._registry['pool3d'] = function(inputsShapes, parameters) { return []; };
+        this._registry['pooling'] = function(inputsShapes, parameters) {
+            if (parameters.padding == 'VALID') {
+                const out_h = ~~((inputsShapes[0][1] + parameters.stride_h - parameters.ksize_h) / parameters.stride_h);
+                const out_w = ~~((inputsShapes[0][2] + parameters.stride_w - parameters.ksize_w) / parameters.stride_w);
+                return [[inputsShapes[0][0], out_h, out_w, inputsShapes[0][3]]];
+            }
+            else if (parameters.padding == 'SAME') {
+                const out_h = ~~((inputsShapes[0][1] + parameters.stride_h - 1) / parameters.stride_h);
+                const out_w = ~~((inputsShapes[0][2] + parameters.stride_w - 1) / parameters.stride_w);
+                return [[inputsShapes[0][0], out_h, out_w, inputsShapes[0][3]]];
+            }
+        };
+        this._registry['poolwithargmax'] = function(inputsShapes, parameters) { return []; };
+        this._registry['postprocess'] = function(inputsShapes, parameters) { return []; };
+        this._registry['pow'] = this._no_shape_changed;
+        this._registry['prelu'] = this._no_shape_changed;
+        this._registry['preprocess'] = function(inputsShapes, parameters) { return []; };
+        this._registry['primary_capsule'] = function(inputsShapes, parameters) { return []; };
+        this._registry['priorbox'] = function(inputsShapes, parameters) { return []; };
+        this._registry['proposal'] = function(inputsShapes, parameters) { return []; };
+        this._registry['quantize'] = this._no_shape_changed;
+        this._registry['real_div'] = function(inputsShapes, parameters) { return []; };
+        this._registry['reconstruction_loss'] = function(inputsShapes, parameters) { return []; };
+        this._registry['recurrent'] = function(inputsShapes, parameters) { return []; };
+        this._registry['reducemax'] = function(inputsShapes, parameters) { return []; };
+        this._registry['reducemean'] = function(inputsShapes, parameters) { return []; };
+        this._registry['reducemin'] = function(inputsShapes, parameters) { return []; };
+        this._registry['reducesum'] = function(inputsShapes, parameters) { return []; };
+        this._registry['region'] = function(inputsShapes, parameters) { return []; };
+        this._registry['relu'] = this._no_shape_changed;
+        this._registry['relu_keras'] = this._no_shape_changed;
+        this._registry['relun'] = this._no_shape_changed;
+        this._registry['reorg'] = function(inputsShapes, parameters) { return []; };
+        this._registry['reshape'] = function(inputsShapes, parameters) { return []; };
+        this._registry['resizebilinear_image'] = function(inputsShapes, parameters) { return []; };
+        this._registry['resizenearest_image'] = function(inputsShapes, parameters) { return []; };
+        this._registry['reverse'] = function(inputsShapes, parameters) { return []; };
+        this._registry['reverse_sequence'] = function(inputsShapes, parameters) { return []; };
+        this._registry['roipooling'] = function(inputsShapes, parameters) { return []; };
+        this._registry['route_train'] = function(inputsShapes, parameters) { return []; };
+        this._registry['rsqrt'] = this._no_shape_changed;
+        this._registry['scatternd'] = function(inputsShapes, parameters) { return []; };
+        this._registry['shuffle'] = function(inputsShapes, parameters) { return []; };
+        this._registry['sigmoid'] = this._no_shape_changed;
+        this._registry['signalframe'] = function(inputsShapes, parameters) { return []; };
+        this._registry['simplernn_keras'] = function(inputsShapes, parameters) { return []; };
+        this._registry['sin'] = this._no_shape_changed;
+        this._registry['slice'] = function(inputsShapes, parameters) { return []; };
+        this._registry['softmax'] = this._no_shape_changed;
+        this._registry['softmax_with_logits_loss_layer'] = function(inputsShapes, parameters) { return []; };
+        this._registry['softrelu'] = this._no_shape_changed;
+        this._registry['space2batch'] = function(inputsShapes, parameters) { return []; };
+        this._registry['space2depth'] = function(inputsShapes, parameters) { return []; };
+        this._registry['split'] = function(inputsShapes, parameters) { return []; };
+        this._registry['sqlite_input_layer'] = function(inputsShapes, parameters) { return []; };
+        this._registry['sqrt'] = this._no_shape_changed;
+        this._registry['square'] = this._no_shape_changed;
+        this._registry['squashing'] = function(inputsShapes, parameters) { return []; };
+        this._registry['squeeze'] = function(inputsShapes, parameters) { return []; };
+        this._registry['stack'] = function(inputsShapes, parameters) { return []; };
+        this._registry['stack_concat'] = function(inputsShapes, parameters) { return []; };
+        this._registry['stridedslice'] = function(inputsShapes, parameters) { return []; };
+        this._registry['subgraph'] = function(inputsShapes, parameters) { return []; };
+        this._registry['subtract'] = function(inputsShapes, parameters) { return []; };
+        this._registry['svdf'] = function(inputsShapes, parameters) { return []; };
+        this._registry['swish'] = function(inputsShapes, parameters) { return []; };
+        this._registry['tanh'] = this._no_shape_changed;
+        this._registry['text_input_layer'] = function(inputsShapes, parameters) { return []; };
+        this._registry['tile'] = function(inputsShapes, parameters) { return []; };
+        this._registry['topk'] = function(inputsShapes, parameters) { return []; };
+        this._registry['topk_score'] = function(inputsShapes, parameters) { return []; };
+        this._registry['unstack'] = function(inputsShapes, parameters) { return []; };
+        this._registry['upsampling'] = function(inputsShapes, parameters) { return []; };
+        //this._registry['variable'] = function(inputsShapes, parameters) { return []; };
+        this._registry['where'] = function(inputsShapes, parameters) { return []; };
+        this._registry['word2vec_input'] = function(inputsShapes, parameters) { return []; };
+        this._registry['yolo'] = function(inputsShapes, parameters) { return []; };
+        this._registry['yoloprocess'] = function(inputsShapes, parameters) { return []; };
+    }
+
+    get(op) {
+        if (Object.prototype.hasOwnProperty.call(this._registry, op)) {
+            return this._registry[op];
+        }
+        else {
+            return function(inputsShapes, parameters) {
+                return [];
+            };
+        }
+    }
+};
+
+acuity.Utility = class {
+
+    static getTensorUrl(layerName, port) {
+        return "@" + layerName + ":" + port;
+    }
+};
+
+acuity.Error = class extends Error {
+
+    constructor(message) {
+        super(message);
+        this.name = 'Error loading Acuity model.';
+    }
+};
+
+if (typeof module !== 'undefined' && typeof module.exports === 'object') {
+    module.exports.ModelFactory = acuity.ModelFactory;
+}

--- a/source/view.js
+++ b/source/view.js
@@ -1215,6 +1215,7 @@ view.ModelFactoryService = class {
         this.register('./npz', [ '.npz', '.h5', '.hd5', '.hdf5' ]);
         this.register('./dl4j', [ '.zip' ]);
         this.register('./mlnet', [ '.zip' ]);
+        this.register('./acuity', [ '.json' ]);
     }
 
     register(id, extensions) {

--- a/test/models.json
+++ b/test/models.json
@@ -1,5 +1,11 @@
 [
   {
+    "type":   "acuity",
+    "target": "inception_v1.json",
+    "source": "https://raw.githubusercontent.com/VeriSilicon/acuity-models/master/models/inception_v1/inception_v1.json",
+    "link":   "https://github.com/VeriSilicon/acuity-models"
+  },
+  {
     "type":   "any",
     "target": "config.json",
     "source": "https://github.com/lutzroeder/netron/files/5398758/config.json.zip[config.json]",


### PR DESCRIPTION
Hi,

This patch enables the support of Acuity models, please help to review the patch, any suggestions are welcome.

Acuity is an AI framework that can convert the models of other framework(such as tensorflow, tflite, caffe, onnx, etc) to Acuity models, then generate high performance code for embedded platforms.

`.json` file is the Acuity model file which contains the model structure, and `.data` file will be loaded for weights and biases, `.quantize` file is for quanzation parameters. the output tensors' shape of each layer will be inferred if the input shape(s) are provied in model files.

Some popular models converted by Acuity can be found here: https://verisilicon.github.io/acuity-models/

Thanks.

#657