### PR TITLE
Library import not needed (and was breaking for py3)

### DIFF
--- a/source/server.py
+++ b/source/server.py
@@ -8,7 +8,6 @@ import sys
 import threading
 import webbrowser
 import time
-import urllib.parse
 
 from .__version__ import __version__
 


### PR DESCRIPTION
Server was breaking for python3.
It's already imported properly in the lines below, so no additional code needed.

I found this while trying to fiddle with something else.

I'd appreciate if you find the PR acceptable, if you could tag it with a "hacktoberfest-accepted" label.