### PR TITLE
Fix rogue process for second instance of app

### DIFF
--- a/source/app.js
+++ b/source/app.js
@@ -22,6 +22,7 @@ class Application {
 
         if (!electron.app.requestSingleInstanceLock()) {
             electron.app.quit();
+            return;
         }
 
         electron.app.on('second-instance', (event, commandLine, workingDirectory) => {


### PR DESCRIPTION
Fixes #322 

More details are in that issue, but essentially this is due to other code executing past the electron.app.quit() call since it doesn't terminate immediately.