### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Netron has experimental support for **TensorFlow** (`.pb`, `.meta`, `.pbtxt`, `.
 
 ## Install
 
-**macOS**: [**Download**](https://github.com/lutzroeder/netron/releases/latest) the `.dmg` file or run `brew cask install netron`
+**macOS**: [**Download**](https://github.com/lutzroeder/netron/releases/latest) the `.dmg` file or run `brew install --cask netron`
 
 **Linux**: [**Download**](https://github.com/lutzroeder/netron/releases/latest) the `.AppImage` file or run `snap install netron`
 


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but README.md needs to be fixed.

Close #661 