### PR TITLE
[OpenVINO] Add id for labelElement

### DIFF
--- a/source/view-grapher.js
+++ b/source/view-grapher.js
@@ -70,6 +70,7 @@ grapher.Renderer = class {
                 const labelElement = this.createElement('g');
                 labelElement.style.opacity = 0;
                 labelElement.setAttribute('class', 'edge-label');
+                labelElement.setAttribute('id', `label-${edge.id}`);
                 labelElement.appendChild(textContainer);
                 svgEdgeLabelGroup.appendChild(labelElement);
                 const edgeBox = textContainer.getBBox();


### PR DESCRIPTION
@lutzroeder, 
As far as we know, OpenVINO is an inference-oriented DL framework. OpenVINO actively uses Netron as a viewer for machine learning models. Our team is going to change some functionality and visualize layer precision value instead of shape value. Label ids will help us correlate layer with revelant LabelElement.
Thank you!