### PR TITLE
Edit view export method

### DIFF
--- a/source/view.js
+++ b/source/view.js
@@ -1059,7 +1059,6 @@ view.View = class {
                     const context = canvas.getContext('2d');
                     context.scale(scale, scale);
                     context.drawImage(imageElement, 0, 0);
-                    this._host.document.body.removeChild(imageElement);
                     canvas.toBlob((blob) => {
                         if (blob) {
                             this._host.export(file, blob);
@@ -1074,7 +1073,6 @@ view.View = class {
                     }, 'image/png');
                 };
                 imageElement.src = 'data:image/svg+xml;base64,' + this._host.window.btoa(unescape(encodeURIComponent(data)));
-                this._host.document.body.insertBefore(imageElement, this._host.document.body.firstChild);
             }
         }
     }


### PR DESCRIPTION
Hello, @lutzroeder. I`ve explored Netron for a few months as part of OpenVino feature. So I observe that when I download the graph as a png image, I see a strange screen jump. I removed a part of the code responsible for that and it didn't affect the image.
Can you explain, please, why are these actions necessary? Can we remove it?
