### PR TITLE
Set bypass cache query parameter on model URL in key=value format

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -435,6 +435,7 @@ host.BrowserHost = class {
     }
 
     _openModel(url, identifier) {
+        url = url + ((/\?/).test(url) ? "&" : "?") + "netronBypassCache=" + (new Date()).getTime();
         this._view.show('welcome spinner');
         this._request(url).then((buffer) => {
             const context = new host.BrowserHost.BrowserContext(this, url, identifier, buffer);

--- a/source/index.js
+++ b/source/index.js
@@ -435,7 +435,6 @@ host.BrowserHost = class {
     }
 
     _openModel(url, identifier) {
-        url = url + ((/\?/).test(url) ? "&" : "?") + (new Date()).getTime();
         this._view.show('welcome spinner');
         this._request(url).then((buffer) => {
             const context = new host.BrowserHost.BrowserContext(this, url, identifier, buffer);


### PR DESCRIPTION
Fixes #708. The value only parameter otherwise breaks some query parameter parsers,
such as the one of mlflow.