### PR TITLE
Add prefix option for serving behind proxy

### DIFF
--- a/source/server.py
+++ b/source/server.py
@@ -53,7 +53,7 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
         buffer = None
         data = '/data/'
         if status_code == 0:
-            if pathname[-1] == '/':
+            if pathname == '/' or pathname == self.prefix:
                 meta = []
                 meta.append('<meta name="type" content="Python">')
                 meta.append('<meta name="version" content="' + __version__ + '">')
@@ -128,6 +128,8 @@ class HTTPServerThread(threading.Thread):
         else:
             self.server.RequestHandlerClass.folder = ''
             self.server.RequestHandlerClass.file = ''
+        if len(prefix) > 0 and not prefix[-1] == '/':
+            prefix = prefix + '/'
         self.server.RequestHandlerClass.prefix = prefix
         self.server.RequestHandlerClass.data = data
         self.server.RequestHandlerClass.log = log


### PR DESCRIPTION
I do most of my work on a remote machine using JupyterHub which is a proxy in front of my Jupyter instance. I use [jupyter-server-proxy](https://github.com/jupyterhub/jupyter-server-proxy) to expose ports through the proxy (ex. http://192.168.1.2/notebook/mine/temp_nb/proxy/8081/ where netron is serving on port 8081). 

The current version of netron does not work with this setup since it serves the model file from the top level of the server path. I added a parameter to allow the user to tell the server what path it is being served on underneath the top address and prepend that to the serving path of the model. This should not have any affect for users who are using netron normally.

Not sure if you want this in the main repository but figured I would share the work I did in case anyone else has the same use case. Thanks for the great work!