### PR TITLE
xmodel: visualization

### DIFF
--- a/source/om.js
+++ b/source/om.js
@@ -437,52 +437,12 @@ om.TensorShape = class {
     }
 };
 
-om.BinaryReader = class {
-
-    constructor(buffer) {
-        this._buffer = buffer;
-        this._length = buffer.length;
-        this._position = 0;
-        this._view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
-    }
-
-    seek(position) {
-        this._position = position >= 0 ? position : this._length + position;
-    }
-
-    skip(offset) {
-        this._position += offset;
-    }
-
-    read(length) {
-        if (this._position === 0 && length === undefined) {
-            this._position = this._length;
-            return this._buffer;
-        }
-        const position = this._position;
-        this.skip(length !== undefined ? length : this._length - this._position);
-        return this._buffer.subarray(position, this._position);
-    }
-
-    byte() {
-        const position = this._position;
-        this.skip(1);
-        return this._buffer[position];
-    }
-
-    uint32() {
-        const position = this._position;
-        this.skip(4);
-        return this._view.getUint32(position, true);
-    }
-};
-
 om.File = class {
 
     static open(context) {
         const stream = context.stream;
         const buffer = stream.peek();
-        const reader = new om.BinaryReader(buffer);
+        const reader = new om.File.BinaryReader(buffer);
         return new om.File(reader);
     }
 
@@ -549,6 +509,46 @@ om.File = class {
                 }
             }
         }
+    }
+};
+
+om.File.BinaryReader = class {
+
+    constructor(buffer) {
+        this._buffer = buffer;
+        this._length = buffer.length;
+        this._position = 0;
+        this._view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+    }
+
+    seek(position) {
+        this._position = position >= 0 ? position : this._length + position;
+    }
+
+    skip(offset) {
+        this._position += offset;
+    }
+
+    read(length) {
+        if (this._position === 0 && length === undefined) {
+            this._position = this._length;
+            return this._buffer;
+        }
+        const position = this._position;
+        this.skip(length !== undefined ? length : this._length - this._position);
+        return this._buffer.subarray(position, this._position);
+    }
+
+    byte() {
+        const position = this._position;
+        this.skip(1);
+        return this._buffer[position];
+    }
+
+    uint32() {
+        const position = this._position;
+        this.skip(4);
+        return this._view.getUint32(position, true);
     }
 };
 

--- a/source/view-grapher.css
+++ b/source/view-grapher.css
@@ -35,7 +35,17 @@
 .node-item-type-tensor path { fill: rgb(89, 66, 59); }
 .node-item-type-transform path { fill: rgb(51, 85, 68); }
 .node-item-type-data path { fill: rgb(85, 85, 85); }
+.node-item-type-quantization path { fill: rgb(105, 105, 105); }
 .node-item-type-custom path { fill: rgb(128, 128, 128); }
+
+.node-item-type-cpu path { fill: rgba(51, 85, 51); }
+.node-item-type-dpu path {  fill: rgb(51, 85, 136);  }
+.node-item-type-dpu0 path {  fill: rgb(69, 71, 112);  }
+.node-item-type-dpu1 path {  fill: rgb(108, 79, 71);  }
+.node-item-type-dpu2 path {  fill: rgb(85, 85, 85);  }
+.node-item-type-dpu3 path {  fill: rgb(51, 85, 136);  }
+.node-item-type-dpu4 path {  fill: rgb(128, 128, 128);  }
+.node-item-type-dpu5 path {  fill: rgb(99, 97, 76);  }
 
 .node-item-input path { fill: #fff; }
 .node-item-input:hover { cursor: pointer; }
@@ -67,7 +77,7 @@
 #arrowhead-vee { fill: #000; }
 .edge-path-control-dependency { stroke-dasharray: 3, 2; }
 
-.cluster rect { stroke: #000; fill: #000; fill-opacity: 0.02; stroke-opacity: 0.06; stroke-width: 1px; }
+.cluster rect { stroke: #000; fill: #000; fill-opacity: 0.02; stroke-opacity: 0.2; stroke-width: 1px; }
 
 .select .node.border { stroke: #e00; stroke-width: 2px; }
 .select.edge-path { stroke: #e00; stroke-width: 2px; marker-end: url("#arrowhead-vee-select"); }

--- a/source/view-grapher.js
+++ b/source/view-grapher.js
@@ -165,6 +165,32 @@ grapher.Graph = class {
             }
         }
 
+        let add_listener = (nodeId) => {
+            const lastIndex = nodeId.lastIndexOf('/');
+            if (!cluster.has(nodeId)) {
+                let parent = nodeId.substring(0, lastIndex);
+                if (parent)
+                    add_listener(parent);
+                let node = this.node(nodeId);
+                node.element.addEventListener('click', node.ShowClusterAttr);
+                cluster.add(nodeId);
+            }
+        };
+
+        let cluster = new Set();
+        for (const nodeId of this.nodes()) {
+            let node = this.node(nodeId);
+            if (node.ShowClusterAttr) {
+                add_listener(nodeId);
+            }
+            if (node.level) {
+                let textElement = createElement('text');
+                textElement.textContent = node.level;
+                node.text = textElement;
+                node.element.appendChild(textElement);
+            }
+        }
+
         for (const edgeId of this.edges()) {
             const edge = this.edge(edgeId);
             edge.build(document, edgePathGroup, edgeLabelGroup);
@@ -189,6 +215,11 @@ grapher.Graph = class {
                 node.rectangle.setAttribute('y', - node.height / 2 );
                 node.rectangle.setAttribute('width', node.width);
                 node.rectangle.setAttribute('height', node.height);
+                if (node.text) {
+                    node.text.setAttribute('y', - node.height / 2);
+                    node.text.setAttribute('text-anchor', 'middle');
+                    node.text.setAttribute('font-size', '20px');
+                }
             }
         }
 
@@ -751,7 +782,6 @@ grapher.Edge = class {
         return {x: x + sx, y: y + sy};
     }
 };
-
 
 if (typeof module !== 'undefined' && typeof module.exports === 'object') {
     module.exports.Graph = grapher.Graph;

--- a/source/view-sidebar.js
+++ b/source/view-sidebar.js
@@ -124,6 +124,54 @@ sidebar.Sidebar = class {
     }
 };
 
+sidebar.SubgraphSidebar = class {
+
+    constructor(host, subgraph) {
+        this._host = host;
+        this._subgraph = subgraph;
+        this._elements = [];
+        this._attributes = [];
+
+        if (subgraph.name) {
+            this._addProperty('name', new sidebar.ValueTextView(this._host, subgraph.name));
+        }
+        const attributes = subgraph.attributes;
+        if (attributes && attributes.length > 0) {
+            this._addHeader('Attributes');
+            for (const attribute of attributes) {
+                this._addAttribute(attribute.name, attribute);
+            }
+        }
+
+        const divider = this._host.document.createElement('div');
+        divider.setAttribute('style', 'margin-bottom: 20px');
+        this._elements.push(divider);
+    }
+
+    render() {
+        return this._elements;
+    }
+
+    _addProperty(name, value) {
+        const item = new sidebar.NameValueView(this._host, name, value);
+        this._elements.push(item.render());
+    }
+
+    _addHeader(title) {
+        const headerElement = this._host.document.createElement('div');
+        headerElement.className = 'sidebar-view-header';
+        headerElement.innerText = title;
+        this._elements.push(headerElement);
+    }
+
+    _addAttribute(name, attribute) {
+        const item = new sidebar.NameValueView(this._host, name, new NodeAttributeView(this._host, attribute));
+        this._attributes.push(item);
+        this._elements.push(item.render());
+    }
+
+};
+
 sidebar.NodeSidebar = class {
 
     constructor(host, node) {
@@ -698,10 +746,55 @@ sidebar.ArgumentView = class {
             typeLine.innerHTML = 'type: <code><b>' + type.toString().split('<').join('&lt;').split('>').join('&gt;') + '</b></code>';
             this._element.appendChild(typeLine);
         }
+        if (argument.xmodel) {
+            if (argument.shape) {
+                const Line = this._host.document.createElement('div');
+                Line.className = 'sidebar-view-item-value-line-border';
+                Line.innerHTML = '<span class=\'sidebar-view-item-value-line-content\'>' + "shape" + ': <b>[' + argument.shape + ']</b></span>';
+                this._element.appendChild(Line);
+            }
+            if (argument.attributes.length > 0) {
+                this._attr_expander = this._host.document.createElement('div');
+                this._attr_expander.className = 'sidebar-view-item-value-expander';
+                this._attr_expander.innerText = '+ MORE ATTRS';
+                this._attr_expander.addEventListener('click', () => {
+                    this.toggle_attr(argument.attributes);
+                });
+                this._element.appendChild(this._attr_expander);
+            }
+            if (argument.data_type) {
+                const Line = this._host.document.createElement('div');
+                Line.className = 'sidebar-view-item-value-line-border';
+                Line.innerHTML = '<span class=\'sidebar-view-item-value-line-content\'>' + "type" + ': <b>' + argument.data_type + '</b></span>';
+                this._element.appendChild(Line);
+            }
+        }
     }
 
     render() {
         return this._element;
+    }
+
+    toggle_attr(attrs) {
+        if(this._attr_expander) {
+            if (this._attr_expander.innerText == '+ MORE ATTRS') {
+                this._attr_expander.innerText = '- FOLD ATTRS';
+                for (const attr of attrs) {
+                    if (attr.name && typeof attr.name === 'string') {
+                        const Line = this._host.document.createElement('div');
+                        Line.className = 'sidebar-view-item-value-line-border';
+                        Line.innerHTML = attr.name +  ':<b>' + sidebar.NodeSidebar.formatAttributeValue(attr.value) + '</b>';
+                        this._element.appendChild(Line);
+                    }
+                }
+            }
+            else {
+                this._attr_expander.innerText = '+ MORE ATTRS';
+                while (this._element.childElementCount > 4) {
+                    this._element.removeChild(this._element.lastChild);
+                }
+            }
+        }
     }
 
     toggle() {
@@ -2189,6 +2282,7 @@ if (typeof module !== 'undefined' && typeof module.exports === 'object') {
     module.exports.Sidebar = sidebar.Sidebar;
     module.exports.ModelSidebar = sidebar.ModelSidebar;
     module.exports.NodeSidebar = sidebar.NodeSidebar;
+    module.exports.SubgraphSidebar = sidebar.SubgraphSidebar;
     module.exports.DocumentationSidebar = sidebar.DocumentationSidebar;
     module.exports.FindSidebar = sidebar.FindSidebar;
 }

--- a/source/view.js
+++ b/source/view.js
@@ -597,6 +597,15 @@ view.View = class {
                     }
                 }
 
+                if (groups && graph.xmodel) {
+                    for (const key of clusterParentMap.keys()) {
+                        let subgraph = graph.subgraphs.get(key);
+                        subgraph.ShowClusterAttr = () => {
+                            this.showSubgraphProperties(subgraph);
+                        };
+                    }
+                }
+
                 for (const node of nodes) {
 
                     const viewNode = viewGraph.createNode(node);
@@ -633,13 +642,24 @@ view.View = class {
                         }
                     }
 
-                    const createCluster = function(name) {
+                    const createCluster = (name) => {
                         if (!clusters.has(name)) {
-                            viewGraph.setNode({ name: name, rx: 5, ry: 5});
                             clusters.add(name);
                             const parent = clusterParentMap.get(name);
                             if (parent) {
                                 createCluster(parent);
+                            }
+                            if (graph.xmodel) {
+                                let subgraph = graph.subgraphs.get(name);
+                                viewGraph.setNode({
+                                    name: name, rx: 5, ry: 5, level: subgraph.level, ShowClusterAttr: () => {
+                                        subgraph.ShowClusterAttr();
+                                    }
+                                });
+                            } else {
+                                viewGraph.setNode({ name: name, rx: 5, ry: 5});
+                            }
+                            if (parent){
                                 viewGraph.setParent(name, parent);
                             }
                         }
@@ -914,6 +934,13 @@ view.View = class {
                 this._updateActiveGraph(name);
             });
             this._sidebar.open(modelSidebar.render(), 'Model Properties');
+        }
+    }
+
+    showSubgraphProperties(subgraph) {
+        if (subgraph) {
+            const subgraphSidebar = new sidebar.SubgraphSidebar(this._host, subgraph);
+            this._sidebar.open(subgraphSidebar.render(), 'Subgraph Properties');
         }
     }
 

--- a/source/xmodel.js
+++ b/source/xmodel.js
@@ -267,7 +267,7 @@ xmodel.Argument = class {
 xmodel.Node = class {
 
     constructor(metadata, op_node, tensors) {
-        this._type = metadata.type(op_node.op_type) || { name: op_node.op_type };
+        this._type = Object.assign({}, metadata.type(op_node.op_type)) || { name: op_node.op_type };
         this._name = op_node.op_name || '';
         this._inputs = [];
         this._outputs = [];

--- a/source/xmodel.js
+++ b/source/xmodel.js
@@ -267,9 +267,8 @@ xmodel.Argument = class {
 xmodel.Node = class {
 
     constructor(metadata, op_node, tensors) {
-        this._type = op_node.op_type;
+        this._type = metadata.type(op_node.op_type) || { name: op_node.op_type };
         this._name = op_node.op_name || '';
-        this._metadata = Object.assign({}, metadata.type(this._type));
         this._inputs = [];
         this._outputs = [];
         this._attributes = [];
@@ -303,7 +302,7 @@ xmodel.Node = class {
     }
 
     set_category(category) {
-        this._metadata.category = category;
+        this._type.category = category;
     }
 
     get type() {

--- a/source/xmodel.js
+++ b/source/xmodel.js
@@ -63,6 +63,8 @@ xmodel.Graph = class {
         const metadata = new xmodel.Metadata(graph.op_defs);
         this._inputs = [];
         this._outputs = [];
+        this._root_subgraph = new xmodel.Subgraph(graph.subg_root);
+        this._handlers = new Map();
         const count = new Map();
         for (const op_node of graph.op_node) {
             for (const arg of op_node.args) {
@@ -71,25 +73,46 @@ xmodel.Graph = class {
                 }
             }
         }
-        const initializers = new Map();
         const nodes = [];
         for (const op_node of graph.op_node) {
-            if (op_node.op_type === 'const-fix' && op_node.args.length === 0 && count.get(op_node.op_name) === 1) {
-                const type = xmodel.Utility.type(op_node.op_attr);
-                initializers.set(op_node.op_name, new xmodel.Tensor(type, op_node.op_type));
-                continue;
-            }
-            if (op_node.op_type === 'data-fix' && op_node.args.length === 0) {
-                const type = xmodel.Utility.type(op_node.op_attr);
-                const quantization = xmodel.Utility.quantization(op_node.op_attr);
-                this._inputs.push(new xmodel.Parameter(op_node.op_name, [
-                    new xmodel.Argument(op_node.op_name, type, quantization.out, null)
-                ]));
-                continue;
-            }
             nodes.push(op_node);
         }
-        this._nodes = nodes.map((node) => new xmodel.Node(metadata, node, initializers));
+
+        let tensors = new Map();
+        for (const op_node of nodes) {
+            tensors.set(op_node.op_name, op_node.output_tensor);
+        }
+
+        this._nodes = nodes.map((node) => new xmodel.Node(metadata, node, tensors));
+
+        let idx = 0;
+        let subgraphs = new Map();
+        (function add_subgraph(parent) {
+            subgraphs.set(parent.group_name, parent);
+            for (const child of parent.children)
+                add_subgraph(child);
+        })(this._root_subgraph);
+
+        this._subgraphs = subgraphs;
+        for (const subgraph of subgraphs.values()) {
+            for (const op of subgraph.ops) {
+                for (let node of this._nodes)
+                    if (op == node.name) {
+                        node.set_group(subgraph.group_name);
+                        let atttributes = new Map();
+                        node.attributes.map((attr) => atttributes.set(attr.name, attr.value));
+                        if (atttributes.has('device') && atttributes.get('device') == 'DPU') {
+                            node.set_category('DPU' + (idx % 6).toString());
+                        }
+                        break;
+                    }
+            }
+            if (subgraph.ops.length > 0) idx++;
+        }
+    }
+
+    set_handler(name, handler) {
+        this._handlers.set(name, handler);
     }
 
     get inputs() {
@@ -102,6 +125,82 @@ xmodel.Graph = class {
 
     get nodes() {
         return this._nodes;
+    }
+
+    get root() {
+        return this._root_subgraph;
+    }
+
+    get subgraphs() {
+        return this._subgraphs;
+    }
+
+    get groups() {
+        return true;
+    }
+
+    get xmodel() {
+        return true;
+    }
+};
+
+xmodel.Subgraph = class {
+
+    constructor(subgraph, parent_name) {
+        this._name = subgraph.subgraph_name;
+        this._children = [];
+        this._ops = subgraph.op_name.length > 0 ? subgraph.op_name : [];
+        this._attributes = [];
+        this._group_name = parent_name ? parent_name + '/' + this._name.replace(/\//g, "_") : this._name;
+        this._show_cluster_attr = undefined;
+        this._level = undefined;
+
+        for (const child of subgraph.subg_child) {
+            this._children.push(new xmodel.Subgraph(child, this._group_name));
+        }
+
+        if (!parent_name) this._level = 'ROOT Subgraph';
+        for (const name of Object.keys(subgraph.subg_attr)) {
+            if (name == 'reg_id_to_parameter_value')
+                continue;
+            if (name == 'device')
+                this._level = subgraph.subg_attr[name].string_value + ' Subgraph';
+            const attribute = xmodel.Utility.attribute(subgraph.subg_attr[name]);
+            this._attributes.push(new xmodel.Attribute(null, name, attribute.type, attribute.value));
+        }
+
+    }
+
+    set ShowClusterAttr(func) {
+        this._show_cluster_attr = func;
+    }
+
+    get ShowClusterAttr() {
+        return this._show_cluster_attr;
+    }
+
+    get attributes() {
+        return this._attributes;
+    }
+
+    get children() {
+        return this._children;
+    }
+
+    get ops() {
+        return this._ops;
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    get group_name() {
+        return this._group_name;
+    }
+
+    get level() {
+        return this._level;
     }
 };
 
@@ -127,74 +226,84 @@ xmodel.Parameter = class {
 
 xmodel.Argument = class {
 
-    constructor(name, type, quantization, initializer) {
-        if (typeof name !== 'string') {
-            throw new xmodel.Error("Invalid argument identifier '" + JSON.stringify(name) + "'.");
+    constructor(proto_tensor) {
+        if (typeof proto_tensor.tensor_name !== 'string') {
+            throw new xmodel.Error("Invalid argument identifier '" + JSON.stringify(proto_tensor.tensor_name) + "'.");
         }
-        this._name = name;
-        this._type = type || null;
-        this._quantization = quantization;
-        this._initializer = initializer || null;
+        this._name = proto_tensor.tensor_name;
+        this._shape = proto_tensor.tensor_dim;
+        this._data_type = xmodel.Utility.type2str(proto_tensor.data_type);
+        this._bit_width = proto_tensor.tensor_bit_width;
+        this._attributes = [];
+
+        for (const key of Object.keys(proto_tensor.tensor_attr)) {
+            if (key.startsWith('quant_in_') || key.startsWith('quant_out_'))
+                continue;
+            const attribute = xmodel.Utility.attribute(proto_tensor.tensor_attr[key]);
+            this._attributes.push(new xmodel.Attribute(undefined, key, attribute.type, attribute.value));
+        }
     }
 
     get name() {
         return this._name;
     }
-
-    get type() {
-        if (this._initializer) {
-            return this._initializer.type;
-        }
-        return this._type;
+    get shape() {
+        return this._shape;
     }
-
-    get quantization() {
-        if (this._quantization) {
-            const list = [];
-            if (this._quantization.bit_width !== undefined) {
-                list.push('bit_width: ' + this._quantization.bit_width);
-            }
-            if (this._quantization.pos !== undefined) {
-                list.push('pos: ' + this._quantization.pos);
-            }
-            if (this._quantization.signed !== undefined) {
-                list.push('signed: ' + this._quantization.signed);
-            }
-            if (this._quantization.round_mode !== undefined) {
-                list.push('round_mode: ' + this._quantization.round_mode);
-            }
-            return list.join(', ');
-        }
-        return null;
+    get data_type() {
+        return this._data_type;
     }
-
-    get initializer() {
-        return this._initializer;
+    get bit_width() {
+        return this._bit_width;
+    }
+    get attributes() {
+        return this._attributes;
+    }
+    get xmodel() {
+        return true;
     }
 };
 
 xmodel.Node = class {
 
-    constructor(metadata, op_node, initializers) {
+    constructor(metadata, op_node, tensors) {
+        this._type = op_node.op_type;
         this._name = op_node.op_name || '';
-        this._type = metadata.type(op_node.op_type) || { name: op_node.op_type };
+        this._metadata = Object.assign({}, metadata.type(this._type));
         this._inputs = [];
         this._outputs = [];
         this._attributes = [];
-        for (const name of Object.keys(op_node.op_attr)) {
-            if (!name.startsWith('quant_in_') && !name.startsWith('quant_out_') && name !== 'workload') {
-                const attribute = xmodel.Utility.attribute(op_node.op_attr[name]);
-                this._attributes.push(new xmodel.Attribute(metadata.attribute(this._type, name), name, attribute.type, attribute.value));
+        this._group = '';
+
+        for (const key of Object.keys(op_node.op_attr)) {
+            if (key.startsWith('quant_in_') || key.startsWith('quant_out_'))
+                continue;
+            if (key == 'data' && Object.keys(op_node.op_attr).includes('data_type')) {
+                let data_type = op_node.op_attr['data_type'].string_value;
+                let data =
+                    xmodel.Utility.transform((new Uint8Array(op_node.op_attr[key].bytes_value.value)).buffer, data_type);
+                this._attributes.push(new xmodel.Attribute(undefined, key, op_node.op_attr['data'].value.replace(/_value$/, ''), data));
+            } else {
+                const attribute = xmodel.Utility.attribute(op_node.op_attr[key]);
+                this._attributes.push(new xmodel.Attribute(metadata.attribute(this._type, key), key, attribute.type, attribute.value));
             }
         }
-        const quantization = xmodel.Utility.quantization(op_node.op_attr);
+
         for (const arg of op_node.args) {
-            const args = arg.arg_ops.map((arg_op) => new xmodel.Argument(arg_op, null, quantization.in, initializers.get(arg_op)));
-            this._inputs.push(new xmodel.Parameter(arg.arg_name, args));
+            const args = arg.arg_ops.map((arg_op) => new xmodel.Argument(tensors.get(arg_op)));
+            if (args.length > 0)
+                this._inputs.push(new xmodel.Parameter(arg.arg_name, args));
         }
-        this._outputs.push(new xmodel.Parameter('output', [
-            new xmodel.Argument(op_node.op_name, null, quantization.out, null)
-        ]));
+        const args = new xmodel.Argument(tensors.get(op_node.op_name));
+        if (args) this._outputs.push(new xmodel.Parameter('output', [args]));
+    }
+
+    set_group(group) {
+        this._group = group;
+    }
+
+    set_category(category) {
+        this._metadata.category = category;
     }
 
     get type() {
@@ -215,6 +324,10 @@ xmodel.Node = class {
 
     get attributes() {
         return this._attributes;
+    }
+
+    get group() {
+        return this._group;
     }
 };
 
@@ -351,30 +464,82 @@ xmodel.Utility = class {
             value: attr[key],
             type: key.replace(/_value$/, '')
         };
+        let map_type = ['bool_vec',
+            'int32_vec',
+            'uint32_vec',
+            'int64_vec',
+            'uint64_vec',
+            'float_vec',
+            'double_vec',
+            'string_vec',
+            'bytes_vec',
+            'map_string_2_int32',
+            'map_string_2_uint32',
+            'map_string_2_int64',
+            'map_string_2_uint64',
+            'map_string_2_string',
+            'map_string_2_bytes',
+            'map_string_2_int32_vec',
+            'map_string_2_uint32_vec',
+            'map_string_2_int64_vec',
+            'map_string_2_uint64_vec',
+            'map_string_2_string_vec'];
+        if (map_type.includes(value.type)) {
+            value.value = value.value.value;
+        }
         switch (value.type) {
             case 'bool': {
                 value.type = 'boolean';
-                break;
-            }
-            case 'int32_vec': {
-                value.type = 'int32[]';
-                value.value = value.value.value;
                 break;
             }
         }
         return value;
     }
 
-    static type(attr) {
-        let dataType = '?';
-        const data_type = attr.data_type.string_value;
-        switch (data_type) {
-            case 'XINT4': dataType = 'int4'; break;
-            case 'XINT8': dataType = 'int8'; break;
-            default: throw new xmodel.Error("Unknown data_type '" + data_type + "'.");
+    static transform(buffer, dtype) {
+        let value = [];
+        let idx = 0;
+        let max_num = 512;
+        switch (dtype.toUpperCase()) {
+            case "XINT8":
+                let i8 = new Int8Array(buffer);
+                while (idx < i8.length && idx < max_num)
+                    value.push(i8[idx++]);
+                break;
+            case "INT32":
+                let i32 = new Int32Array(buffer);
+                while (idx < i32.length && idx < max_num)
+                    value.push(i32[idx++]);
+                break;
+            case "INT64":
+                let i64 = new BigInt64Array(buffer);
+                while (idx < i64.length && idx < max_num)
+                    value.push(i64[idx++]);
+                break;
+            case "FLOAT32":
+                let f32 = new Float32Array(buffer);
+                while (idx < f32.length && idx < max_num)
+                    value.push(f32[idx++]);
+                break;
         }
-        const shape = attr.shape.int32_vec_value.value;
-        return new xmodel.TensorType(dataType, new xmodel.TensorShape(shape));
+        return value;
+    }
+
+    static type2str(index) {
+        switch (index) {
+            case 0:
+                return "INT";
+            case 1:
+                return "UINT";
+            case 2:
+                return "XINT";
+            case 3:
+                return "XUINT";
+            case 4:
+                return "FLOAT";
+            default:
+                return "UNKNOWN";
+        }
     }
 
     static quantization(attr) {
@@ -418,14 +583,48 @@ xmodel.Metadata = class {
         this._map = new Map();
         this._attributeCache = new Map();
         const categories = new Map([
-            [ 'conv2d-fix', 'Layer' ],
-            [ 'depthwise-conv2d-fix', 'Layer' ],
-            [ 'upsample-fix', 'Layer' ],
-            [ 'pool-fix', 'Pool' ],
+            [ 'conv2d', 'Layer' ],
+            [ 'depthwise-conv2d', 'Layer' ],
+            [ 'transposed-conv2d', 'Layer' ],
+            [ 'transposed-depthwise-conv2d', 'Layer' ],
+            [ 'inner-product', 'Layer' ],
+            [ 'matmul', 'Layer' ],
+            [ 'scale', 'Layer' ],
+            [ 'maxpool2d', 'Pool' ],
+            [ 'avgpool2d', 'Pool' ],
+            [ 'relu', 'Activation' ],
+            [ 'leaky-relu', 'Activation' ],
+            [ 'relu6', 'Activation' ],
+            [ 'elu', 'Activation' ],
+            [ 'celu', 'Activation' ],
+            [ 'gelu', 'Activation' ],
+            [ 'selu', 'Activation' ],
+            [ 'sigmoid', 'Activation' ],
+            [ 'swish', 'Activation' ],
+            [ 'tanh', 'Activation' ],
+            [ 'hard-sigmoid', 'Activation' ],
+            [ 'hard-swish', 'Activation' ],
+            [ 'hard-tanh', 'Activation' ],
+            [ 'fix', 'Quantization' ],
+            [ 'fix2float', 'Quantization' ],
+            [ 'float2fix', 'Quantization' ],
+            [ 'threshold', 'Quantization' ],
             [ 'batchnorm', 'Normalization' ],
-            [ 'concat-fix', 'Tensor' ],
-            [ 'reshape-fix', 'Shape' ],
-            [ 'softmax', 'Activation' ]
+            [ 'l2_normalize', 'Normalization' ],
+            [ 'concat', 'Tensor' ],
+            [ 'identity', 'Tensor' ],
+            [ 'upload', 'Tensor' ],
+            [ 'download', 'Tensor' ],
+            [ 'placeholder', 'Tensor' ],
+            [ 'squeeze', 'Tensor' ],
+            [ 'transpose', 'Tensor' ],
+            [ 'flatten', 'Tensor' ],
+            [ 'placeholder', 'Tensor' ],
+            [ 'strided_slice', 'Tensor' ],
+            [ 'stack', 'Tensor' ],
+            [ 'gstiling', 'Tensor' ],
+            [ 'reshape', 'Shape' ],
+            [ 'shape', 'Shape' ]
         ]);
         for (const op_def of op_defs) {
             const name = op_def.name;


### PR DESCRIPTION
Hi, lutzroeder:
We really appreciate your work about Netron, which is widely used by us. I tried to optimize the visualization of xmodel. Please have a look at this patch, could these changes be merged into your main branch ?

New Features:
1. Visualize the subgraphs for the .xmodel files.
2. Display the attributes of tensors.
3. Change the color.

Some Examples:
![image](https://user-images.githubusercontent.com/66007608/131305747-f0e7a651-1af1-4661-98dd-eb7f7c0b11a0.png)
![image](https://user-images.githubusercontent.com/66007608/131305608-d3ad6085-18f4-4daf-bda1-be618f4c56e3.png)

#718