### PR TITLE
readme add HiAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Netron is a viewer for neural network, deep learning and machine learning models. 
 
-Netron supports ONNX, TensorFlow Lite, Keras, Caffe, Darknet, ncnn, MNN, PaddlePaddle, Core ML, MXNet, RKNN, MindSpore Lite, TNN, Barracuda, Tengine, TensorFlow.js, Caffe2 and UFF.
+Netron supports ONNX, TensorFlow Lite, Keras, Caffe, Darknet, ncnn, MNN, PaddlePaddle, Core ML, MXNet, RKNN, MindSpore Lite, TNN, Barracuda, Tengine, TensorFlow.js, Caffe2, UFF and HiAI.
 
 Netron has experimental support for PyTorch, TensorFlow, TorchScript, OpenVINO, Torch, Vitis AI, Arm NN, BigDL, Chainer, CNTK, Deeplearning4j, MediaPipe, ML.NET and scikit-learn.
 


### PR DESCRIPTION
HiAI(https://developer.huawei.com/consumer/cn/hiai/) is well known as an AI framework.   
DaVinci OM is its model, like the relationship of pb model and tensorflow .   
Readme adding HiAI is good for HiAI user's model visualization with Netron.  