### PR TITLE
TensorFlow: Visualize missing functions in pbtxts

### DIFF
--- a/source/tf.js
+++ b/source/tf.js
@@ -1041,7 +1041,9 @@ tf.Attribute = class {
                 this._type = 'function';
                 this._value = metadata.type(name);
                 if (!this._value) {
-                    throw new tf.Error("Unknown function '" + name + "'.");
+                    // Function was not found in the pbtxt, but we can still visualize the graph
+                    this._type = 'string';
+                    this._value = name + " (not found)";
                 }
                 break;
             }


### PR DESCRIPTION
Hi Lutz,

Recently, I've tried reducing the size of dumped graphs by TensorFlow, by not storing functions data in the files.
Instead, each function, since it's a self-contained graph, is stored as a separate file. 
This reduces the size of files containing nodes with functions significantly, as functions can describe very complex subgraphs.

Netron is not visualizing the content of functions currently, or at least I could not find it in the GUI.
In any case, I propose fixing it by printing the function names as string type + 'not found' suffix, so that such graphs can still be visualized.

Let me know, what you think.

Cheers,
Michał

#838