### PR TITLE
fix reading boolean tensor from onnx

### DIFF
--- a/source/onnx.js
+++ b/source/onnx.js
@@ -757,6 +757,7 @@ onnx.Tensor = class {
         this._kind = kind || null;
         const data = (tensor) => {
             let data = undefined;
+            let int32_data = undefined
             if (tensor.data_location === onnx.DataLocation.DEFAULT) {
                 switch (tensor.data_type) {
                     case onnx.DataType.FLOAT16:
@@ -780,9 +781,10 @@ onnx.Tensor = class {
                         data = new Float64Array(tensor.double_data);
                         break;
                     case onnx.DataType.BOOL:
-                        data = new Array(tensor.int32_data.size);
+                        int32_data = new Int32Array(tensor.int32_data);
+                        data = new Array(tensor.int32_data.length)
                         for (let i = 0; i < data.length; i++) {
-                            data[i] = data[i] === 0 ? false : true;
+                            data[i] = int32_data[i] === 0 ? false : true;
                         }
                         break;
                     case onnx.DataType.INT8:


### PR DESCRIPTION
Current code cannot read boolean tensor correctly. This is a fix.

In the original code, the `tensor.int32_data` is never read and the property `tensor.int32_data.size` does not exist, and is `undefined`. This makes boolean tensors using either `int32_data` or `raw_data` cannot be read in correctly.

Attached file is an onnx graph to that has two `Where` node, whose "condition" input are two `Constant` node with boolean tensors using `int32_data` and `raw_data`.

[where.onnx.zip](https://github.com/lutzroeder/netron/files/7601390/where.onnx.zip)
