### PR TITLE
remove length limit on displayed shape

### DIFF
--- a/source/view.js
+++ b/source/view.js
@@ -1223,7 +1223,6 @@ view.Argument = class {
                     type.shape.dimensions.length > 0 &&
                     type.shape.dimensions.every((dim) => !dim || Number.isInteger(dim) || dim instanceof base.Int64 || (typeof dim === 'string'))) {
                     content = type.shape.dimensions.map((dim) => dim || '?').join('\u00D7');
-                    content = content.length > 16 ? '' : content;
                 }
                 if (this.context.view.showNames) {
                     content = this._argument.name.split('\n').shift(); // custom argument id


### PR DESCRIPTION
This continues #835.

Netron now displays the shapes, but have length limit of 16 for the whole string. This limit did not exist before v5.2.7.

In my real graphs, when I want to use some meaning for names for the dimensions, like "batch", "sequence", the length of for the entire shape can easily exceed that limit, like "batch x 12 x sequence x 64". It get even long in complex graphs.

So here I propose to remove that limit.