### PR TITLE
fix(source/ncnn-metadata.json): add missing layernorm affine

### DIFF
--- a/source/ncnn-metadata.json
+++ b/source/ncnn-metadata.json
@@ -517,7 +517,8 @@
     "category": "Normalization",
     "attributes": [
       { "name": "channels", "default": 0 },
-      { "name": "eps", "type": "float32", "default": 0.001 }
+      { "name": "eps", "type": "float32", "default": 0.001 },
+      { "name": "affine", "type": "int32", "default": 1 }
     ]
   },
   {


### PR DESCRIPTION
Add missing attr `affine` when parsing ncnn model.

AKA this:
![image](https://user-images.githubusercontent.com/7872421/164426980-a0d0722f-ba6c-449a-aa7d-94871882108d.png)

cc [@nihui](https://github.com/nihui) 
