### PR TITLE
Add optional bias input to TransposeConv in TFLite

### DIFF
--- a/source/tflite-metadata.json
+++ b/source/tflite-metadata.json
@@ -935,7 +935,8 @@
     "inputs": [
       { "name": "output_shape" },
       { "name": "weights" },
-      { "name": "input" }
+      { "name": "input" },
+      { "name": "bias", "description": "(optional)" }
     ],
     "outputs": [
       { "name": "output" }


### PR DESCRIPTION
Currently, the TransposeConv operator only displays "4" as the name of the bias input to TransposeConv.
This commit copies the bias definition from Conv2D to TransposeConv.

(Sorry for the extra whitespace at the bottom, I used the default GitHub editor and could not change that. If it is wrong, please feel free to modify it)