### PR TITLE
Show error dialog when filename does not have an extension.

### DIFF
--- a/source/app.js
+++ b/source/app.js
@@ -242,6 +242,9 @@ class Application {
             };
             const selectedFile = electron.dialog.showSaveDialogSync(owner, showSaveDialogOptions);
             if (selectedFile) {
+                if (!/\.png$|\.svg$/i.test(selectedFile)) {
+                    electron.dialog.showErrorBox("Export error", "The chosen filename does not end in .png or .svg! \n\nPlease try again.");
+                }
                 view.execute('export', { 'file': selectedFile });
             }
         }


### PR DESCRIPTION
This is a quick and dirty fix for #861. I haven't found how to automatically add the extension to the filename when it doesn't have one, because I can't find how to get the extension from the type selector in the showSaveDialog box. 

Either way, this should really be fixed upstream instead, but this is just a minimal fix so the user can at least know that the file didn't save.

