### PR TITLE
Load scripts in parallel to reduce total page load time by ~2 seconds

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -21,7 +21,7 @@
                 let scriptEl = document.createElement("script");
                 scriptEl.onload = resolve;
                 scriptEl.src = url;
-                document.body.appendChild(scriptEl);
+                document.head.appendChild(scriptEl);
             });
         }
         let urls = ["dagre.js","base.js","text.js","json.js","xml.js","python.js","protobuf.js","flatbuffers.js","flexbuffers.js","zip.js","gzip.js","tar.js","view-grapher.js","view-sidebar.js","view.js"];

--- a/source/index.html
+++ b/source/index.html
@@ -14,22 +14,23 @@
 <link rel="apple-touch-icon" type="image/png" href="icon.png">
 <link rel="apple-touch-icon-precomposed" type="image/png" href="icon.png">
 <link rel="fluid-icon" type="image/png" href="icon.png">
-<script type="text/javascript" src="dagre.js"></script>
-<script type="text/javascript" src="base.js"></script>
-<script type="text/javascript" src="text.js"></script>
-<script type="text/javascript" src="json.js"></script>
-<script type="text/javascript" src="xml.js"></script>
-<script type="text/javascript" src="python.js"></script>
-<script type="text/javascript" src="protobuf.js"></script>
-<script type="text/javascript" src="flatbuffers.js"></script>
-<script type="text/javascript" src="flexbuffers.js"></script>
-<script type="text/javascript" src="zip.js"></script>
-<script type="text/javascript" src="gzip.js"></script>
-<script type="text/javascript" src="tar.js"></script>
-<script type="text/javascript" src="view-grapher.js"></script>
-<script type="text/javascript" src="view-sidebar.js"></script>
-<script type="text/javascript" src="view.js"></script>
-<script type="text/javascript" src="index.js"></script>
+<script>
+    (async function() {
+        function addScript(url) {
+            return new Promise(resolve => {
+                let scriptEl = document.createElement("script");
+                scriptEl.onload = resolve;
+                scriptEl.src = url;
+                document.body.appendChild(scriptEl);
+            });
+        }
+        let urls = ["dagre.js","base.js","text.js","json.js","xml.js","python.js","protobuf.js","flatbuffers.js","flexbuffers.js","zip.js","gzip.js","tar.js","view-grapher.js","view-sidebar.js","view.js"];
+        let scriptLoadPromises = urls.map(url => addScript(url));
+        await Promise.all(scriptLoadPromises);
+        await addScript("index.js");
+        console.log("Finished loading scripts.");
+    })();
+</script>
 <style>
 html { touch-action: none; overflow: hidden; width: 100%; height: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; text-rendering: optimizeLegibility; -webkit-text-rendering: optimizeLegibility; -moz-text-rendering: optimizeLegibility; -ms-text-rendering: optimizeLegibility; -o-text-rendering: optimizeLegibility; -webkit-font-smoothing: antialiased; -moz-font-smoothing: antialiased; -ms-font-smoothing: antialiased; -o-font-smoothing: antialiased; }
 body { touch-action: none; overflow: hidden; width: 100%; height: 100%; margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "Ubuntu", "Droid Sans", sans-serif, "PingFang SC"; font-size: 12px; text-rendering: geometricPrecision; }


### PR DESCRIPTION
I noticed that the loading was a bit slow due to the serial loading of the scripts:

https://user-images.githubusercontent.com/1167575/195853315-650fb495-4e5b-4d69-8049-2b6555cf2007.mp4

This patch should cut load time down from ~4 seconds to ~2 seconds. It assumes that all scripts other than `index.js` can be loaded in parallel.

Please feel free to close this pull request if you'd rather implement this in a different way (e.g. by bundling the scripts).

Thanks for all your work on this project!