### PR TITLE
docs(readme): add --cask for brew command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Netron has experimental support for PyTorch, TensorFlow, TorchScript, OpenVINO, 
 
 ## Install
 
-**macOS**: [**Download**](https://github.com/lutzroeder/netron/releases/latest) the `.dmg` file or run `brew install netron`
+**macOS**: [**Download**](https://github.com/lutzroeder/netron/releases/latest) the `.dmg` file or run `brew install --cask netron`
 
 **Linux**: [**Download**](https://github.com/lutzroeder/netron/releases/latest) the `.AppImage` file or run `snap install netron`
 


### PR DESCRIPTION
Just a small update. Change from

```shell
brew install netron
```

to 

```shell
brew install --cask netron
```

based on https://formulae.brew.sh/cask/netron#default

Because usually `--cask` is GUI app.

When I saw `brew install netron`, I initially thought it is a CLI command without GUI.

😃