### PR TITLE
Avoid reflow in mouse down handler

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -24,6 +24,7 @@ button { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI"
 .open-file-dialog { display: none; }
 .transparent { width: 100%; height: 100%; background-color: #000000; display: none; opacity: 0; }
 .graph { display: flex; height: 100%; width: 100%; overflow: auto; outline: none; touch-action: pan-x pan-y; }
+.cursor { position: absolute; height: 100%; width: 100%;}
 .canvas { margin: auto; flex-shrink: 0; text-rendering: geometricPrecision; user-select: none; -webkit-user-select: none; -moz-user-select: none; }
 .toolbar { position: absolute; top: 10px; left: 10px; padding: 0; margin: 0; user-select: none; -webkit-user-select: none; -moz-user-select: none; }
 .toolbar button:focus { outline: 0; }
@@ -164,6 +165,7 @@ button { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI"
 <body class="welcome spinner">
 <div id="graph" class="graph" tabindex="0">
     <svg id="canvas" class="canvas" preserveaspectratio="xMidYMid meet" width="100%" height="100%"></svg>
+    <div id="cursor" class="cursor"></div>
 </div>
 <div id="sidebar" class="sidebar"></div>
 <div id="toolbar" class="toolbar">

--- a/source/index.html
+++ b/source/index.html
@@ -24,7 +24,7 @@ button { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI"
 .open-file-dialog { display: none; }
 .transparent { width: 100%; height: 100%; background-color: #000000; display: none; opacity: 0; }
 .graph { display: flex; height: 100%; width: 100%; overflow: auto; outline: none; touch-action: pan-x pan-y; }
-.cursor { position: absolute; height: 100%; width: 100%;}
+.cursor { position: absolute; height: 100%; width: 100%; pointer-events: none;}
 .canvas { margin: auto; flex-shrink: 0; text-rendering: geometricPrecision; user-select: none; -webkit-user-select: none; -moz-user-select: none; }
 .toolbar { position: absolute; top: 10px; left: 10px; padding: 0; margin: 0; user-select: none; -webkit-user-select: none; -moz-user-select: none; }
 .toolbar button:focus { outline: 0; }

--- a/source/view.js
+++ b/source/view.js
@@ -225,14 +225,15 @@ view.View = class {
     _mouseDownHandler(e) {
         if (e.buttons === 1) {
             const document = this._host.document.documentElement;
-            document.style.cursor = 'grabbing';
             const container = this._getElementById('graph');
+            const cursor = this._getElementById('cursor');
             this._mousePosition = {
                 left: container.scrollLeft,
                 top: container.scrollTop,
                 x: e.clientX,
                 y: e.clientY
             };
+            cursor.style.cursor = 'grabbing';
             e.stopImmediatePropagation();
             const mouseMoveHandler = (e) => {
                 e.preventDefault();
@@ -247,7 +248,7 @@ view.View = class {
                 }
             };
             const mouseUpHandler = () => {
-                document.style.cursor = null;
+                cursor.style.cursor = null;
                 container.removeEventListener('mouseup', mouseUpHandler);
                 container.removeEventListener('mouseleave', mouseUpHandler);
                 container.removeEventListener('mousemove', mouseMoveHandler);


### PR DESCRIPTION
The dragging latency is too high due to forced reflow.

<img width="498" alt="Screenshot 2022-11-30 at 12 19 11 PM" src="https://user-images.githubusercontent.com/75532970/204707427-a05f5078-a2e6-4385-86d9-7ac9142d395b.png">

This pull request move the cursor layer to separated div to avoid layout reflow.

<img width="468" alt="Screenshot 2022-11-30 at 12 21 18 PM" src="https://user-images.githubusercontent.com/75532970/204707414-1f3c98ba-30ad-4842-8df9-a2506095cd25.png">
