### PR TITLE
Reduce dragging latency

### DIFF
--- a/source/view.js
+++ b/source/view.js
@@ -225,14 +225,15 @@ view.View = class {
     _mouseDownHandler(e) {
         if (e.buttons === 1) {
             const document = this._host.document.documentElement;
-            document.style.cursor = 'grabbing';
             const container = this._getElementById('graph');
+            const background = this._getElementById('background');
             this._mousePosition = {
                 left: container.scrollLeft,
                 top: container.scrollTop,
                 x: e.clientX,
                 y: e.clientY
             };
+            background.setAttribute('cursor', 'grabbing')
             e.stopImmediatePropagation();
             const mouseMoveHandler = (e) => {
                 e.preventDefault();
@@ -247,7 +248,7 @@ view.View = class {
                 }
             };
             const mouseUpHandler = () => {
-                document.style.cursor = null;
+                background.setAttribute('cursor', 'default')
                 container.removeEventListener('mouseup', mouseUpHandler);
                 container.removeEventListener('mouseleave', mouseUpHandler);
                 container.removeEventListener('mousemove', mouseMoveHandler);


### PR DESCRIPTION
The dragging latency is too high due forced reflow on whole page.

![Screenshot 2022-11-30 at 10 55 54 PM](https://user-images.githubusercontent.com/75532970/204831076-8e8720e4-61d0-4443-8fef-72c886074024.png)

This pull request set cursor attribute on background svg element instead.
![Screenshot 2022-11-30 at 10 55 17 PM](https://user-images.githubusercontent.com/75532970/204831170-9e840bf8-cbcf-4a61-8ed0-2c3a6ef06c83.png)



