### PR TITLE
Enable highlighting edges from NodeSidebar

### DIFF
--- a/source/grapher.css
+++ b/source/grapher.css
@@ -64,13 +64,12 @@
 .graph-item-output:hover path { fill: #fff; }
 
 .edge-label { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "Ubuntu", "Droid Sans", sans-serif, "PingFang SC"; font-size: 10px; }
-.edge-path { stroke: #000; stroke-width: 1px; fill: none; marker-end: url("#arrowhead"); }
+.edge-path { pointer-events: var(--pointer-events, none); stroke: #000; stroke-width: var(--stroke-width, 1px); fill: none; marker-end: url("#arrowhead"); }
 #arrowhead { fill: #000; }
 .edge-path-control-dependency { stroke-dasharray: 3, 2; }
 
-.edge-path-hover { pointer-events: stroke; stroke-width: 0.5em; fill: none; stroke-opacity: 0; }
-.edge-path-hover:hover + .edge-path { stroke: #e00; marker-end: url("#arrowhead-hover"); }
-.edge-path:hover { stroke: #e00; marker-end: url("#arrowhead-hover"); }
+.edge-path-hover { --pointer-events: auto; --stroke-width: 0.75em; stroke-opacity: 0; }
+.edge-path-hover:hover + .edge-path, .edge-path.hover { stroke: #e00; marker-end: url("#arrowhead-hover"); }
 #arrowhead-hover { fill: #e00; }
 
 .select .node.border { stroke: #e00; stroke-width: 2px; }
@@ -86,10 +85,6 @@
     .edge-label { fill: #b2b2b2; }
     .edge-path { stroke: #888; }
     #arrowhead { fill: #888; }
-
-    .edge-path-hover:hover + .edge-path { stroke: #b00; marker-end: url("#arrowhead-hover"); }
-    .edge-path:hover { stroke: #b00; marker-end: url("#arrowhead-hover"); }
-    #arrowhead-hover { fill: #b00; }
 
     .node path { stroke: #1d1d1d; }
     .node line { stroke: #1d1d1d; }

--- a/source/grapher.js
+++ b/source/grapher.js
@@ -539,15 +539,17 @@ grapher.Edge = class {
             return document.createElementNS('http://www.w3.org/2000/svg', name);
         };
         this.element = createElement('path');
+        let id = '';
         if (this.id) {
-            this.element.setAttribute('data-id', this.id);
-            this.element.setAttribute('id', this.id + '_' + edgePathGroupElement.children.length);
+            id = this.id.split('\n')[0];
+            this.element.setAttribute('data-id', id);
+            this.element.setAttribute('id', id + '_' + edgePathGroupElement.children.length);
         }
         this.element.setAttribute('class', this.class ? 'edge-path ' + this.class : 'edge-path');
         edgePathGroupElement.appendChild(this.element);
         this.hitTestElement = createElement('use');
         this.hitTestElement.setAttribute('class', 'edge-path-hover');
-        this.hitTestElement.setAttribute('href', '#' + this.element.getAttribute('id'));
+        this.hitTestElement.setAttribute('href', '#' + this.element.id);
         edgePathGroupElement.insertBefore(this.hitTestElement, this.element);
         if (this.label) {
             const tspan = createElement('tspan');
@@ -560,7 +562,7 @@ grapher.Edge = class {
             this.labelElement.style.opacity = 0;
             this.labelElement.setAttribute('class', 'edge-label');
             if (this.id) {
-                this.labelElement.setAttribute('data-id', 'edge-label-' + this.id);
+                this.labelElement.setAttribute('data-id', 'edge-label-' + id);
             }
             edgeLabelGroupElement.appendChild(this.labelElement);
             const edgeBox = this.labelElement.getBBox();

--- a/source/grapher.js
+++ b/source/grapher.js
@@ -125,7 +125,7 @@ grapher.Graph = class {
             element.setAttribute('viewBox', '0 0 10 10');
             element.setAttribute('refX', 9);
             element.setAttribute('refY', 5);
-            element.setAttribute('markerUnits', 'strokeWidth');
+            element.setAttribute('markerUnits', 'userSpaceOnUse');
             element.setAttribute('markerWidth', 8);
             element.setAttribute('markerHeight', 6);
             element.setAttribute('orient', 'auto');
@@ -538,15 +538,17 @@ grapher.Edge = class {
         const createElement = (name) => {
             return document.createElementNS('http://www.w3.org/2000/svg', name);
         };
-        this.hitTestElement = createElement('path');
-        this.hitTestElement.setAttribute('class', 'edge-path-hover');
-        edgePathGroupElement.appendChild(this.hitTestElement);
         this.element = createElement('path');
         if (this.id) {
-            this.element.setAttribute('id', this.id);
+            this.element.setAttribute('data-id', this.id);
+            this.element.setAttribute('id', this.id + '_' + edgePathGroupElement.children.length);
         }
         this.element.setAttribute('class', this.class ? 'edge-path ' + this.class : 'edge-path');
         edgePathGroupElement.appendChild(this.element);
+        this.hitTestElement = createElement('use');
+        this.hitTestElement.setAttribute('class', 'edge-path-hover');
+        this.hitTestElement.setAttribute('href', '#' + this.element.getAttribute('id'));
+        edgePathGroupElement.insertBefore(this.hitTestElement, this.element);
         if (this.label) {
             const tspan = createElement('tspan');
             tspan.setAttribute('xml:space', 'preserve');
@@ -558,7 +560,7 @@ grapher.Edge = class {
             this.labelElement.style.opacity = 0;
             this.labelElement.setAttribute('class', 'edge-label');
             if (this.id) {
-                this.labelElement.setAttribute('id', 'edge-label-' + this.id);
+                this.labelElement.setAttribute('data-id', 'edge-label-' + this.id);
             }
             edgeLabelGroupElement.appendChild(this.labelElement);
             const edgeBox = this.labelElement.getBBox();
@@ -594,7 +596,6 @@ grapher.Edge = class {
         };
         const edgePath = curvePath(this, this.from, this.to);
         this.element.setAttribute('d', edgePath);
-        this.hitTestElement.setAttribute('d', edgePath);
         if (this.labelElement) {
             this.labelElement.setAttribute('transform', 'translate(' + (this.x - (this.width / 2)) + ',' + (this.y - (this.height / 2)) + ')');
             this.labelElement.style.opacity = 1;

--- a/source/view.js
+++ b/source/view.js
@@ -2149,8 +2149,8 @@ view.NodeSidebar = class extends view.Control {
         for (let io of this._inputs.concat(this._outputs)) {
             for (let item of io._value._items) {
                 let edges = edgePathsElement.querySelectorAll('[data-id=\"edge-' + item._argument.name + '\"]');
-                let valueElement = item._element.lastChild;
-                if (edges) {
+                if (edges.length > 0) {
+                    let valueElement = item._element.lastChild;
                     valueElement.addEventListener('pointerenter', function(e){
                         for (let e of this) {
                             e.classList.add('hover');

--- a/source/view.js
+++ b/source/view.js
@@ -944,7 +944,8 @@ view.View = class {
                 if (this._menu) {
                     this._menu.close();
                 }
-                const nodeSidebar = new view.NodeSidebar(this._host, node);
+                const graphElement = this._element('canvas');
+                const nodeSidebar = new view.NodeSidebar(this._host, node, graphElement);
                 nodeSidebar.on('show-documentation', (/* sender, e */) => {
                     this.showDocumentation(node.type);
                 });
@@ -2072,7 +2073,7 @@ view.Control = class {
 
 view.NodeSidebar = class extends view.Control {
 
-    constructor(host, node) {
+    constructor(host, node, graph) {
         super();
         this._host = host;
         this._node = node;
@@ -2140,6 +2141,25 @@ view.NodeSidebar = class extends view.Control {
             this._addHeader('Outputs');
             for (const output of outputs) {
                 this._addOutput(output.name, output);
+            }
+        }
+
+        // hover edges
+        const edgePathsElement = graph.getElementById('edge-paths');
+        for (let item of this._inputs.concat(this._outputs)) {
+            let edges = edgePathsElement.querySelectorAll('[data-id=\"edge-' + item._value._list._arguments[0]._name + '\"]');
+            let valueElement = item.render().lastChild;
+            if (edges) {
+                valueElement.addEventListener('pointerenter', function(e){
+                    for (let e of this) {
+                        e.setAttribute('class', e.getAttribute('class') + ' hover');
+                    }
+                }.bind(edges));
+                valueElement.addEventListener('pointerleave', function(e){
+                    for (let e of this) {
+                        e.setAttribute('class', e.getAttribute('class').replace(' hover', ''));
+                    }
+                }.bind(edges));
             }
         }
 
@@ -2900,7 +2920,7 @@ view.FindSidebar = class extends view.Control {
         const edgePathsElement = this._graphElement.getElementById('edge-paths');
         let edgePathElement = edgePathsElement.firstChild;
         while (edgePathElement) {
-            if (edgePathElement.id == id) {
+            if (edgePathElement.getAttribute('data-id') == id) {
                 selection.push(edgePathElement);
             }
             edgePathElement = edgePathElement.nextSibling;

--- a/source/view.js
+++ b/source/view.js
@@ -2144,11 +2144,12 @@ view.NodeSidebar = class extends view.Control {
             }
         }
 
-        // hover edges
+        // highlight edges
         const edgePathsElement = graph.getElementById('edge-paths');
         for (const io of this._inputs.concat(this._outputs)) {
             for (const item of io._value._items) {
-                const edges = edgePathsElement.querySelectorAll('[data-id="edge-' + item._argument.name + '"]');
+                const argName = item._argument.name.split('\n')[0];
+                const edges = edgePathsElement.querySelectorAll('[data-id="edge-' + CSS.escape(argName) + '"]');
                 if (edges.length > 0) {
                     const valueElement = item._element.lastChild;
                     valueElement.addEventListener('pointerenter', function() {

--- a/source/view.js
+++ b/source/view.js
@@ -2146,20 +2146,22 @@ view.NodeSidebar = class extends view.Control {
 
         // hover edges
         const edgePathsElement = graph.getElementById('edge-paths');
-        for (let item of this._inputs.concat(this._outputs)) {
-            let edges = edgePathsElement.querySelectorAll('[data-id=\"edge-' + item._value._list._arguments[0]._name + '\"]');
-            let valueElement = item.render().lastChild;
-            if (edges) {
-                valueElement.addEventListener('pointerenter', function(e){
-                    for (let e of this) {
-                        e.setAttribute('class', e.getAttribute('class') + ' hover');
-                    }
-                }.bind(edges));
-                valueElement.addEventListener('pointerleave', function(e){
-                    for (let e of this) {
-                        e.setAttribute('class', e.getAttribute('class').replace(' hover', ''));
-                    }
-                }.bind(edges));
+        for (let io of this._inputs.concat(this._outputs)) {
+            for (let item of io._value._items) {
+                let edges = edgePathsElement.querySelectorAll('[data-id=\"edge-' + item._argument.name + '\"]');
+                let valueElement = item._element.lastChild;
+                if (edges) {
+                    valueElement.addEventListener('pointerenter', function(e){
+                        for (let e of this) {
+                            e.classList.add('hover');
+                        }
+                    }.bind(edges));
+                    valueElement.addEventListener('pointerleave', function(e){
+                        for (let e of this) {
+                            e.classList.remove('hover');
+                        }
+                    }.bind(edges));
+                }
             }
         }
 

--- a/source/view.js
+++ b/source/view.js
@@ -2146,19 +2146,19 @@ view.NodeSidebar = class extends view.Control {
 
         // hover edges
         const edgePathsElement = graph.getElementById('edge-paths');
-        for (let io of this._inputs.concat(this._outputs)) {
-            for (let item of io._value._items) {
-                let edges = edgePathsElement.querySelectorAll('[data-id=\"edge-' + item._argument.name + '\"]');
+        for (const io of this._inputs.concat(this._outputs)) {
+            for (const item of io._value._items) {
+                const edges = edgePathsElement.querySelectorAll('[data-id="edge-' + item._argument.name + '"]');
                 if (edges.length > 0) {
-                    let valueElement = item._element.lastChild;
-                    valueElement.addEventListener('pointerenter', function(e){
-                        for (let e of this) {
-                            e.classList.add('hover');
+                    const valueElement = item._element.lastChild;
+                    valueElement.addEventListener('pointerenter', function() {
+                        for (const edge of this) {
+                            edge.classList.add('hover');
                         }
                     }.bind(edges));
-                    valueElement.addEventListener('pointerleave', function(e){
-                        for (let e of this) {
-                            e.classList.remove('hover');
+                    valueElement.addEventListener('pointerleave', function() {
+                        for (const edge of this) {
+                            edge.classList.remove('hover');
                         }
                     }.bind(edges));
                 }


### PR DESCRIPTION
This is a sequel to #1071 .

- Switched to SVG `<use>` element instead of SVG `<path>` element for hover hit-testing of edges.
  - Used `data-id` attribute to avoid duplication of `id` attribute.
  - The above change is necessary because SVG `<use>` elements cannot refer to corresponding edges when `id` attributes of edge `<path>` elements are duplicated.
- Enabled highlighting edges from NodeSidebar's NameValueView elements to show connections.
