### PR TITLE
Show connection on hover without duplicating edges

### DIFF
--- a/source/grapher.css
+++ b/source/grapher.css
@@ -64,13 +64,12 @@
 .graph-item-output:hover path { fill: #fff; }
 
 .edge-label { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "Ubuntu", "Droid Sans", sans-serif, "PingFang SC"; font-size: 10px; }
-.edge-path { stroke: #000; stroke-width: 1px; fill: none; marker-end: url("#arrowhead"); }
+.edge-path { pointer-events: var(--pointer-events, none); stroke: #000; stroke-width: var(--stroke-width, 1px); fill: none; marker-end: url("#arrowhead"); }
 #arrowhead { fill: #000; }
 .edge-path-control-dependency { stroke-dasharray: 3, 2; }
 
-.edge-path-hover { pointer-events: stroke; stroke-width: 0.5em; fill: none; stroke-opacity: 0; }
-.edge-path-hover:hover + .edge-path { stroke: #e00; marker-end: url("#arrowhead-hover"); }
-.edge-path:hover { stroke: #e00; marker-end: url("#arrowhead-hover"); }
+.edge-path-hittest { --pointer-events: auto; --stroke-width: 0.5em; fill: none; stroke-opacity: 0; }
+.edge-path-hittest:hover + .edge-path, edge-path.hover { stroke: #e00; marker-end: url("#arrowhead-hover"); }
 #arrowhead-hover { fill: #e00; }
 
 .select .node.border { stroke: #e00; stroke-width: 2px; }
@@ -87,8 +86,7 @@
     .edge-path { stroke: #888; }
     #arrowhead { fill: #888; }
 
-    .edge-path-hover:hover + .edge-path { stroke: #b00; marker-end: url("#arrowhead-hover"); }
-    .edge-path:hover { stroke: #b00; marker-end: url("#arrowhead-hover"); }
+    .edge-path-hittest:hover + .edge-path, edge-path.hover { stroke: #b00; marker-end: url("#arrowhead-hover"); }
     #arrowhead-hover { fill: #b00; }
 
     .node path { stroke: #1d1d1d; }

--- a/source/grapher.js
+++ b/source/grapher.js
@@ -125,7 +125,7 @@ grapher.Graph = class {
             element.setAttribute('viewBox', '0 0 10 10');
             element.setAttribute('refX', 9);
             element.setAttribute('refY', 5);
-            element.setAttribute('markerUnits', 'strokeWidth');
+            element.setAttribute('markerUnits', 'userSpaceOnUse');
             element.setAttribute('markerWidth', 8);
             element.setAttribute('markerHeight', 6);
             element.setAttribute('orient', 'auto');
@@ -538,15 +538,23 @@ grapher.Edge = class {
         const createElement = (name) => {
             return document.createElementNS('http://www.w3.org/2000/svg', name);
         };
-        this.hitTestElement = createElement('path');
-        this.hitTestElement.setAttribute('class', 'edge-path-hover');
-        edgePathGroupElement.appendChild(this.hitTestElement);
         this.element = createElement('path');
+        let dataId = '';
+        let elementId = '';
         if (this.id) {
-            this.element.setAttribute('id', this.id);
+            // 'data-id' attribute is used to store plain id
+            dataId = this.id;
+            this.element.setAttribute('data-id', dataId);
+            // The 'id' attribute needs to be unique.
+            elementId = CSS.escape(this.id) + '_' + edgePathGroupElement.children.length
+            this.element.setAttribute('id', elementId);
         }
         this.element.setAttribute('class', this.class ? 'edge-path ' + this.class : 'edge-path');
         edgePathGroupElement.appendChild(this.element);
+        this.hitTestElement = createElement('use');
+        this.hitTestElement.setAttribute('class', 'edge-path-hittest');
+        this.hitTestElement.setAttribute('href', '#' + this.element.id);
+        edgePathGroupElement.insertBefore(this.hitTestElement, this.element);
         if (this.label) {
             const tspan = createElement('tspan');
             tspan.setAttribute('xml:space', 'preserve');
@@ -558,7 +566,7 @@ grapher.Edge = class {
             this.labelElement.style.opacity = 0;
             this.labelElement.setAttribute('class', 'edge-label');
             if (this.id) {
-                this.labelElement.setAttribute('id', 'edge-label-' + this.id);
+                this.labelElement.setAttribute('data-id', 'edge-label-' + dataId);
             }
             edgeLabelGroupElement.appendChild(this.labelElement);
             const edgeBox = this.labelElement.getBBox();
@@ -594,7 +602,6 @@ grapher.Edge = class {
         };
         const edgePath = curvePath(this, this.from, this.to);
         this.element.setAttribute('d', edgePath);
-        this.hitTestElement.setAttribute('d', edgePath);
         if (this.labelElement) {
             this.labelElement.setAttribute('transform', 'translate(' + (this.x - (this.width / 2)) + ',' + (this.y - (this.height / 2)) + ')');
             this.labelElement.style.opacity = 1;

--- a/source/grapher.js
+++ b/source/grapher.js
@@ -546,7 +546,7 @@ grapher.Edge = class {
             dataId = this.id;
             this.element.setAttribute('data-id', dataId);
             // The 'id' attribute needs to be unique.
-            elementId = CSS.escape(this.id) + '_' + edgePathGroupElement.children.length
+            elementId = CSS.escape(this.id) + '_' + edgePathGroupElement.children.length;
             this.element.setAttribute('id', elementId);
         }
         this.element.setAttribute('class', this.class ? 'edge-path ' + this.class : 'edge-path');

--- a/source/grapher.js
+++ b/source/grapher.js
@@ -553,7 +553,7 @@ grapher.Edge = class {
         edgePathGroupElement.appendChild(this.element);
         this.hitTestElement = createElement('use');
         this.hitTestElement.setAttribute('class', 'edge-path-hittest');
-        this.hitTestElement.setAttribute('href', '#' + this.element.id);
+        this.hitTestElement.setAttribute('href', '#' + elementId);
         edgePathGroupElement.insertBefore(this.hitTestElement, this.element);
         if (this.label) {
             const tspan = createElement('tspan');

--- a/source/view.js
+++ b/source/view.js
@@ -989,7 +989,7 @@ view.View = class {
                     const edgePathsElement = graphElement.getElementById('edge-paths');
                     let element = edgePathsElement.firstChild;
                     while (element) {
-                        if (element.id == name) {
+                        if (element.getAttribute('data-id') == name) {
                             selection.push(element);
                         }
                         element = element.nextSibling;
@@ -2937,7 +2937,7 @@ view.FindSidebar = class extends view.Control {
         const edgePathsElement = this._graphElement.getElementById('edge-paths');
         let edgePathElement = edgePathsElement.firstChild;
         while (edgePathElement) {
-            if (edgePathElement.id == id) {
+            if (edgePathElement.getAttribute('data-id') == id) {
                 selection.push(edgePathElement);
             }
             edgePathElement = edgePathElement.nextSibling;


### PR DESCRIPTION
Hit-testing is performed with SVG `<use>` tag so there's no need to duplicate edges anymore.
