### PR TITLE
Support oneDNN Boolean data type

### DIFF
--- a/source/onednn.js
+++ b/source/onednn.js
@@ -312,6 +312,7 @@ onednn.TensorType = class {
             case 's32': this._dataType = 'int32'; break;
             case 'u8': this._dataType = 'uint8'; break;
             case 'bf16': this._dataType = 'bfloat16'; break;
+            case 'boolean': this._dataType = 'boolean'; break;
             case 'undef': this._dataType = '?'; break;
             default: throw new onednn.Error("Unsupported tensor data type '" + dataType.toString() + "'.");
         }


### PR DESCRIPTION
oneDNN introduces boolean data type and can be serialized in the graph. https://oneapi-src.github.io/oneDNN/dev_guide_data_types.html#:~:text=precision%20floating%2Dpoint-,boolean,-bool%20(size%20is