### PR TITLE
[PR] Make unit-test-able mlir.js

### DIFF
--- a/source/mlir.js
+++ b/source/mlir.js
@@ -1330,3 +1330,20 @@ mlir.Error = class extends Error {
 if (typeof module !== 'undefined' && typeof module.exports === 'object') {
     module.exports.ModelFactory = mlir.ModelFactory;
 }
+
+// This code is for the runnable test with a mlir file.
+// Usage: `node source/mlir.js <mlir file path>`
+if (process.argv.length >= 3) {
+    const fs = require('fs');
+
+    function runParser(textContent) {
+        const decoder = text.Decoder.open(textContent);
+        const parser = new mlir.Parser(decoder);
+        const obj = parser.read();
+        const model = new mlir.Model(obj);
+    }
+    
+    const mlirFilePath = process.argv[2];
+    const fileText = fs.readFileSync(mlirFilePath, 'utf8');
+    runParser(fileText);    
+}


### PR DESCRIPTION
Once run [this python script](https://gist.github.com/tucan9389/9ce47a8aa3e9bd3be79611ae5f09d91a) with your own mlir file, you can check whether mlir.Parser of source/mlir.js works (error or not).

Here is the table representing the error-free ratio when I run all of the mlir files with our `mlir.Parser` in specific repo.

> it’s quite low ratio btw 🥲

repo name | [tensorflow](https://github.com/tensorflow/tensorflow) | [mlir-hlo](https://github.com/tensorflow/mlir-hlo) | [openxla/iree](https://github.com/openxla/iree) | [llvm-project](https://github.com/llvm/llvm-project) | [llvm/circt](https://github.com/llvm/circt)
-- | -- | -- | -- | -- | -- 
\# of mlir files | 1.5k | 4.4k | 1.1k | 1.3k | 500
success ratio<br>(1.0 is max) | 0.523 | 0.049 | 0.088 | 0.106 | 0.044