### PR TITLE
support visualization for onednn graph inputs outputs

### DIFF
--- a/test/models.json
+++ b/test/models.json
@@ -3347,6 +3347,13 @@
     "link":     "https://github.com/lutzroeder/netron/issues/1006"
   },
   {
+    "type":     "onednn",
+    "target":   "sample-graph-with-ports-100001.json",
+    "source":   "https://github.com/lutzroeder/netron/files/11539630/sample-graph-with-ports-100001.json.zip[sample-graph-with-ports-100001.json]",
+    "format":   "oneDNN Graph v3.0.0",
+    "link":     "https://github.com/lutzroeder/netron/issues/1006"
+  },
+  {
     "type":     "onnx",
     "target":   "arcface-resnet100.onnx",
     "source":   "https://s3.amazonaws.com/onnx-model-zoo/arcface/resnet100/resnet100.onnx",


### PR DESCRIPTION
onednn graph added new entries `input_ports` and `output_ports` to the serialized JSON representing the inputs/outputs of the graph. this pr is to visualize it with Graph inputs/outputs.

e.g. conv->relu with external output

<details><summary>visualization</summary>

<img width="927" alt="Screenshot 2023-05-09 at 17 08 51" src="https://github.com/intel-innersource/libraries.performance.math.onednn/assets/17897736/52c73f95-8ddf-4f1c-9d1c-01ca4367ba5c">

</details>

<details><summary>JSON</summary>

```JSON
{
  "version": "3.1.0",
  "engine_kind": "cpu",
  "fpmath_mode": "strict",
  "input_ports": [
    0, 
    1
  ],
  "output_ports": [
    2,
    3
  ],
  "graph": [
    {
      "id": 0,
      "name": "CONV_0",
      "kind": "Convolution",
      "attrs": {
        "pads_end": {
          "type": "s64[]",
          "value": [
            0, 
            0
          ]
        },
        "auto_pad": {
          "type": "string",
          "value": "None"
        },
        "weights_format": {
          "type": "string",
          "value": "OIX"
        },
        "pads_begin": {
          "type": "s64[]",
          "value": [
            0, 
            0
          ]
        },
        "data_format": {
          "type": "string",
          "value": "NCX"
        },
        "dilations": {
          "type": "s64[]",
          "value": [
            1, 
            1
          ]
        },
        "strides": {
          "type": "s64[]",
          "value": [
            1, 
            1
          ]
        },
        "groups": {
          "type": "s64",
          "value": 1
        }
      },
      "inputs": [
        {
          "id": 0,
          "dtype": "f32",
          "shape": [
            2, 
            32, 
            112, 
            112
          ],
          "stride": [
            401408, 
            12544, 
            112, 
            1
          ],
          "layout_type": "strided",
          "property_type": "undef"
        }, 
        {
          "id": 1,
          "dtype": "f32",
          "shape": [
            64, 
            32, 
            1, 
            1
          ],
          "stride": [
            32, 
            1, 
            1, 
            1
          ],
          "layout_type": "strided",
          "property_type": "constant"
        }
      ],
      "outputs": [
        {
          "id": 2,
          "dtype": "f32",
          "shape": [
            2, 
            64, 
            112, 
            112
          ],
          "stride": [
            802816, 
            12544, 
            112, 
            1
          ],
          "layout_type": "strided",
          "property_type": "undef"
        }
      ]
    }, 
    {
      "id": 1,
      "name": "ELTWISE_1",
      "kind": "ReLU",
      "attrs": {},
      "inputs": [
        {
          "id": 2,
          "dtype": "f32",
          "shape": [
            2, 
            64, 
            112, 
            112
          ],
          "stride": [
            802816, 
            12544, 
            112, 
            1
          ],
          "layout_type": "strided",
          "property_type": "undef"
        }
      ],
      "outputs": [
        {
          "id": 3,
          "dtype": "f32",
          "shape": [
            2, 
            64, 
            112, 
            112
          ],
          "stride": [
            802816, 
            12544, 
            112, 
            1
          ],
          "layout_type": "strided",
          "property_type": "undef"
        }
      ]
    }
  ]
}
```

</details>