### PR TITLE
Toggle visibility of sizes (tensor shapes)

### DIFF
--- a/source/app.js
+++ b/source/app.js
@@ -473,6 +473,11 @@ app.Application = class {
                         click: () => this.execute('toggle', 'names'),
                     },
                     {
+                        id: 'view.toggle-sizes',
+                        accelerator: 'CmdOrCtrl+S',
+                        click: () => this.execute('toggle', 'sizes'),
+                    },
+                    {
                         id: 'view.toggle-direction',
                         accelerator: 'CmdOrCtrl+K',
                         click: () => this.execute('toggle', 'direction')
@@ -585,6 +590,10 @@ app.Application = class {
             commandTable.set('view.toggle-names', {
                 enabled: (view) => view && view.path ? true : false,
                 label: (view) => !view || view.get('names') ? 'Hide &Names' : 'Show &Names'
+            });
+            commandTable.set('view.toggle-sizes', {
+                enabled: (view) => view && view.path ? true : false,
+                label: (view) => !view || view.get('sizes') ? 'Hide &Sizes' : 'Show &Sizes'
             });
             commandTable.set('view.toggle-direction', {
                 enabled: (view) => view && view.path ? true : false,

--- a/source/grapher.js
+++ b/source/grapher.js
@@ -559,15 +559,19 @@ grapher.Edge = class {
         this.hitTest.addEventListener('pointerleave', () => this.emit('pointerleave'));
         edgePathGroupElement.appendChild(this.hitTest);
         if (this.label) {
-            const tspan = createElement('tspan');
-            tspan.setAttribute('xml:space', 'preserve');
-            tspan.setAttribute('dy', '1em');
-            tspan.setAttribute('x', '1');
-            tspan.appendChild(document.createTextNode(this.label));
             this.labelElement = createElement('text');
-            this.labelElement.appendChild(tspan);
             this.labelElement.style.opacity = 0;
             this.labelElement.setAttribute('class', 'edge-label');
+            const lines = this.label.split('\n');
+            const dy = lines.length > 1 ? '1.5em' : '1em';
+            for (const line of lines) {
+                const tspan = createElement('tspan');
+                tspan.setAttribute('xml:space', 'preserve');
+                tspan.setAttribute('dy', dy);
+                tspan.setAttribute('x', '1');
+                tspan.appendChild(document.createTextNode(line));
+                this.labelElement.appendChild(tspan);
+            }
             if (this.id) {
                 this.labelElement.setAttribute('id', 'edge-label-' + this.id);
             }

--- a/source/view.js
+++ b/source/view.js
@@ -19,6 +19,7 @@ view.View = class {
             weights: true,
             attributes: false,
             names: false,
+            sizes: true,
             direction: 'vertical',
             mousewheel: 'scroll'
         };
@@ -134,6 +135,12 @@ view.View = class {
                     label: () => this.options.names ? 'Hide &Names' : 'Show &Names',
                     accelerator: 'CmdOrCtrl+U',
                     execute: () => this.toggle('names'),
+                    enabled: () => this.activeGraph
+                });
+                view.add({
+                    label: () => this.options.sizes ? 'Hide &Sizes' : 'Show &Sizes',
+                    accelerator: 'CmdOrCtrl+S',
+                    execute: () => this.toggle('sizes'),
                     enabled: () => this.activeGraph
                 });
                 view.add({
@@ -291,6 +298,7 @@ view.View = class {
     toggle(name) {
         switch (name) {
             case 'names':
+            case 'sizes':
             case 'attributes':
             case 'weights':
                 this._options[name] = !this._options[name];
@@ -1971,21 +1979,28 @@ view.Value = class {
     build() {
         this._edges = this._edges || [];
         if (this._from && this._to) {
+            const options = this.context.view.options;
             for (let i = 0; i < this._to.length; i++) {
                 const to = this._to[i];
-                let content = '';
-                const type = this.value.type;
-                if (type &&
-                    type.shape &&
-                    type.shape.dimensions &&
-                    type.shape.dimensions.length > 0 &&
-                    type.shape.dimensions.every((dim) => !dim || Number.isInteger(dim) || dim instanceof base.Int64 || (typeof dim === 'string'))) {
-                    content = type.shape.dimensions.map((dim) => (dim !== null && dim !== undefined) ? dim : '?').join('\u00D7');
-                    content = content.length > 16 ? '' : content;
+                let content = [];
+                if (options.names) {
+                    const nameContent = this.value.name.split('\n').shift(); // custom argument id
+                    content.push(nameContent);
                 }
-                if (this.context.view.options.names) {
-                    content = this.value.name.split('\n').shift(); // custom argument id
+                if (options.sizes) {
+                    let sizeContent = '';
+                    const type = this.value.type;
+                    if (type &&
+                        type.shape &&
+                        type.shape.dimensions &&
+                        type.shape.dimensions.length > 0 &&
+                        type.shape.dimensions.every((dim) => !dim || Number.isInteger(dim) || dim instanceof base.Int64 || (typeof dim === 'string'))) {
+                        sizeContent = type.shape.dimensions.map((dim) => (dim !== null && dim !== undefined) ? dim : '?').join('\u00D7');
+                        sizeContent = sizeContent.length > 16 ? '' : sizeContent;
+                    }
+                    content.push(sizeContent);
                 }
+                content = content.join("\n");
                 const edge = new view.Edge(this, this._from, to);
                 edge.v = this._from.name;
                 edge.w = to.name;


### PR DESCRIPTION
This PR adds `Show/Hide Sizes` menu-item to toggle visibility of sizes on edge labels.

![toggle_sizes](https://github.com/lutzroeder/netron/assets/1131125/16f059d4-860f-4a8d-bca2-b00de8db85a1)

#1125 
