### PR TITLE
OpenVINO: fix i4/u8 itemsize

### DIFF
--- a/source/openvino.js
+++ b/source/openvino.js
@@ -485,6 +485,7 @@ openvino.Node = class {
             let itemSize = undefined;
             switch (precision) {
                 case 'BOOL': case 'BOOLEAN':         itemSize = 1; break;
+                case 'I4':  case 'U4':               itemSize = 0.5; break;
                 case 'I8':  case 'U8':               itemSize = 1; break;
                 case 'I16': case 'U16': case 'FP16': itemSize = 2; break;
                 case 'I32': case 'U32': case 'FP32': itemSize = 4; break;

--- a/test/models.json
+++ b/test/models.json
@@ -4231,6 +4231,13 @@
     "link":     "https://github.com/lutzroeder/netron/issues/191"
   },
   {
+    "type":     "openvino",
+    "target":   "openvino_i4_matmul_model.xml,openvino_i4_matmul_model.bin",
+    "source":   "https://github.com/lutzroeder/netron/files/13052433/openvino_i4_matmul_model.zip[openvino_i4_matmul_model.zip]",
+    "format":   "OpenVINO IR",
+    "error":     "Unsupported data type size: i4"
+  },
+  {
     "type":     "paddle",
     "target":   "adam.pdopt",
     "source":   "https://github.com/lutzroeder/netron/files/8882900/adam.pdopt.zip[adam.pdopt]",


### PR DESCRIPTION
I4/U4 does not have right itemSize set which leads to the raising of error.  This fix is to set 0.5 for I4/U4 precision.

[openvino_i4_matmul_model.zip](https://github.com/lutzroeder/netron/files/13052433/openvino_i4_matmul_model.zip)
