### PR TITLE
Add attribute-search to the left sidebar

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -102,6 +102,7 @@ button { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI"
 .menu .menu-group .menu-command:disabled { color: #888888; }
 .menu .menu-group .menu-command .menu-label { display: block; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 .menu .menu-group .menu-command .menu-shortcut { display: block; float: right; margin-left: 25px; color: #888888; }
+.menu .menu-group .menu-text-input { margin-left: 8px; margin-right: 8px; font-size: 12px; border-width: 2px; padding-left: 2px; padding-right: 2px; width: calc(100% - 16px - 4px - 4px); /* width - margin - padding - border */ }
 .menu .menu-group .menu-separator { border-top: 1px; border-bottom: 0; border-style: solid; border-color: #e5e5e5; margin-left: 12px; margin-right: 12px; }
 .about .titlebar-visible { opacity: 0; }
 @-webkit-keyframes orbit { 0% { -webkit-transform: rotate(0deg); transform: rotate(0deg); } 100% { -webkit-transform: rotate(360deg); transform: rotate(360deg); } }

--- a/source/view.js
+++ b/source/view.js
@@ -299,14 +299,16 @@ view.View = class {
     }
 
     toggle(name, newValue) {
-        console.assert(name === 'attributeFilters' || newValue === undefined);
+        if (!(name === 'attributeFilters' || newValue === undefined)) {
+            throw new view.Error("Unsupported toogle value: '" + name + "' = '" + newValue + "'.");
+        }
         switch (name) {
             case 'attributeFilters':
                 this.options.attributeFilters = newValue;
                 // Turn the attributes on if they aren't already. If you request
                 // a filter presumably you want to see them.
                 if (!this.options.attributes) {
-                    this.toggle('attributes')
+                    this.toggle('attributes');
                 } else {
                     // Toggling the attributes will reload, no need to do it
                     // twice in that case.
@@ -1443,8 +1445,8 @@ view.Menu = class {
                     }
                     case 'textinput': {
                         const element = this._document.createElement('input');
-                        element.setAttribute('type', 'text')
-                        element.setAttribute('placeholder', item.placeholderText)
+                        element.setAttribute('type', 'text');
+                        element.setAttribute('placeholder', item.placeholderText);
                         element.setAttribute('class', 'menu-text-input');
                         element.setAttribute('id', item.identifier);
                         element.value = item.startingValue();
@@ -1555,12 +1557,14 @@ view.Menu.Group = class {
         const item = (() => {
             if (value.execute) {
                 return new view.Menu.Command(value);
-            } else if (value.placeholderText) {
-                return new view.Menu.TextInput(value);
-            } else {
-                console.assert(Object.keys(value).length == 0);
-                return new view.Menu.Separator()
             }
+            if (value.placeholderText) {
+                return new view.Menu.TextInput(value);
+            }
+            if (Object.keys(value).length !== 0) {
+                throw new view.Error("Unexpected menu item: '" + value + "'.");
+            }
+            return new view.Menu.Separator();
         })();
         item.identifier = this.identifier + '-' + this.items.length.toString();
         this.items.push(item);


### PR DESCRIPTION
This makes it a lot easier to work with graphs where nodes have a large number of attributes, only a few of which are important.
See the attached screenshot for an example of it working an onnx graph (not really an example of the use-case however).
I didn't realize that electron doesn't have the left sidebar until pretty late, I'm not sure you can directly transpose the code into that version either since I don't *think* the OS top bar will let you add a text-input control, but I'm no expert.
I figured I'd let you decide what's best to do there.
Lint is clean and tests seem to be fine, though I'm not sure that they exercise this code by nature.

<img width="895" alt="filter-attributes-netron" src="https://github.com/lutzroeder/netron/assets/74673334/0bd314a8-67ad-4a89-b6d4-255a2444fc98">