### PR TITLE
Adding Modular support to Netron

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Netron is a viewer for neural network, deep learning and machine learning models
 
 Netron supports ONNX, TensorFlow Lite, Core ML, Keras, Caffe, Darknet, MXNet, PaddlePaddle, ncnn, MNN and TensorFlow.js.
 
-Netron has experimental support for PyTorch, TorchScript, TensorFlow, OpenVINO, RKNN, MediaPipe, ML.NET and scikit-learn.
+Netron has experimental support for PyTorch, TorchScript, TensorFlow, OpenVINO, RKNN, MediaPipe, ML.NET, Modular and scikit-learn.
 
 <p align='center'><a href='https://www.lutzroeder.com/ai'><img src='.github/screenshot.png' width='800'></a></p>
 

--- a/source/mod.js
+++ b/source/mod.js
@@ -1,0 +1,156 @@
+var mod = {};
+
+mod.ModelFactory = class {
+
+    match(context) {
+        const obj = context.open('json');
+        if (obj && obj.signature == "netron:modular") {
+            return 'mod';
+        }
+        return null;
+    }
+
+    async open(context) {
+        return new mod.Model(context);
+    }
+};
+
+mod.Model = class {
+
+    constructor(context) {
+        const obj = context.open('json');
+        this._graphs = obj.graphs.map(graph => new mod.Graph(graph));
+    }
+
+    get format() {
+        return 'Modular';
+    }
+
+    get graphs() {
+        return this._graphs;
+    }
+};
+
+mod.Graph = class {
+
+    constructor(graph) {
+        this._nodes = Array.from(graph.nodes.map(node => new mod.Node(node)));
+        this._inputs = [];
+        this._outputs = [];
+    }
+
+    get inputs() {
+        return this._inputs;
+    }
+
+    get outputs() {
+        return this._outputs;
+    }
+
+    get nodes() {
+        return this._nodes;
+    }
+};
+
+mod.Argument = class {
+
+    constructor(name, value) {
+        this._name = name;
+        this._value = Array.from(value.map(value => new mod.Value(value.toString(), name)));
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    get value() {
+        return this._value;
+    }
+};
+
+mod.Value = class {
+
+    constructor(name, value) {
+        if (typeof name !== 'string') {
+            throw new mod.Error("Invalid value identifier '" + JSON.stringify(name) + "'.");
+        }
+        this._name = name;
+        this._value = value;
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    get value() {
+        return this._value;
+    }
+};
+
+mod.Node = class {
+
+    constructor(node) {
+        this._name = node.type.name;
+        if (node.type.category == 'List') {
+            this._category = 'Data';
+        } else if (node.type.category == 'ControlFlow') {
+            this._category == 'Control';
+        } else {
+            this._category = node.type.category;
+        }
+        this._type = { name: this._name, category: this._category };
+        this._attributes = node.attributes ?
+            Array.from(node.attributes).map(attribute => new mod.Attribute(attribute.name, attribute.value)) :
+            [];
+        this._inputs = Array.from(node.inputs.map(input => new mod.Argument(input.name, input.arguments)));
+        this._outputs = Array.from(node.outputs.map(output => new mod.Argument(output.name, output.arguments)));
+    }
+
+    get type() {
+        return this._type;
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    get inputs() {
+        return this._inputs;
+    }
+
+    get outputs() {
+        return this._outputs;
+    }
+
+    get attributes() {
+        return this._attributes;
+    }
+};
+
+mod.Attribute = class {
+
+    constructor(name, value) {
+        this._name = name;
+        this._value = value;
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    get value() {
+        return this._value;
+    }
+};
+
+mod.Error = class extends Error {
+
+    constructor(message) {
+        super(message);
+        this.name = 'Error loading Modular model.';
+    }
+};
+
+if (typeof module !== 'undefined' && typeof module.exports === 'object') {
+    module.exports.ModelFactory = mod.ModelFactory;
+}

--- a/source/view.js
+++ b/source/view.js
@@ -5188,6 +5188,7 @@ view.ModelFactoryService = class {
         this.register('./hailo', [ '.hn', '.har' ]);
         this.register('./nnc', [ '.nnc' ]);
         this.register('./safetensors', [ '.safetensors' ]);
+        this.register('./mod', [ '.mod' ]);
     }
 
     register(id, factories, containers) {

--- a/test/models.json
+++ b/test/models.json
@@ -2999,6 +2999,13 @@
     "link":     "https://github.com/xindongzhang/MNN-APPLICATIONS"
   },
   {
+    "type":     "modular",
+    "target":   "resnet34.mod",
+    "source":   "https://github.com/lutzroeder/netron/files/13395132/resnet34.mod.zip",
+    "format":   "Modular",
+    "link":     "https://github.com/lutzroeder/netron/pull/1186"
+  },
+  {
     "type":     "mslite",
     "target":   "blazeface_quant.ms",
     "source":   "https://github.com/lutzroeder/netron/files/6097966/blazeface_quant.ms.zip[blazeface_quant.ms]",


### PR DESCRIPTION
Adding the initial support for Modular visualization files (`.mod`) to Netron. This is the first version of this support, and we expect to expand it to add support for shapes and additional attributes in later iterations. 

More context on modular can be found at [modular.com](https://www.modular.com/). Additional information about how to utilize this integration will be released in a few weeks. 