### PR TITLE
Improve SVG building performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
         "electron": "27.1.0",
         "electron-builder": "24.6.4",
         "@electron/notarize": "2.2.0",
-        "eslint": "8.54.0"
+        "eslint": "8.54.0",
+        "canvas": "^2.11.2"
     },
     "eslintConfig": {
         "env": {

--- a/test/models.js
+++ b/test/models.js
@@ -2,6 +2,7 @@
 const fs = require('fs').promises;
 const path = require('path');
 const process = require('process');
+const { createCanvas } = require('canvas');
 
 const base = require('../source/base');
 const view = require('../source/view');
@@ -149,7 +150,10 @@ global.Document = class {
         this.body = new HTMLElement();
     }
 
-    createElement(/* name */) {
+    createElement(name) {
+        if (name === "canvas") {
+            return createCanvas(100, 100);
+        }
         return new HTMLElement();
     }
 


### PR DESCRIPTION
The getBBox function is slow. This commit replaces it with measureText to enhance performance.

Before
<img width="349" alt="Screenshot 2023-11-23 at 11 03 09 AM" src="https://github.com/lutzroeder/netron/assets/75532970/fe43a129-8aca-4457-8b47-3126de19bd8b">

After:
<img width="227" alt="Screenshot 2023-11-23 at 11 04 37 AM" src="https://github.com/lutzroeder/netron/assets/75532970/7e4c4dd3-9be7-45fc-9d33-b016036a96e8">
