### PR TITLE
Hailo: Fix for feature splitter layer shapes labels.

### DIFF
--- a/source/hailo.js
+++ b/source/hailo.js
@@ -45,7 +45,8 @@ hailo.Graph = class {
             } else if (tensor) {
                 throw new hailo.Error("Duplicate value '" + name + "'.");
             } else if (type && !type.equals(args.get(name).type)) {
-                throw new hailo.Error("Duplicate value '" + name + "'.");
+                name = name + '\n';
+                arg(name, type, tensor);
             }
             return args.get(name);
         };


### PR DESCRIPTION
Shapes labels for .hn or .har models always had the same values and now they are fixed. This is the fix for https://github.com/lutzroeder/netron/issues/1197 issue.

![image](https://github.com/lutzroeder/netron/assets/98901220/b3525a7a-6e5f-4b09-b4ce-49cf81c83d45)
