### PR TITLE
Update onednn.js with float8 data types

### DIFF
--- a/source/onednn.js
+++ b/source/onednn.js
@@ -330,6 +330,8 @@ onednn.TensorType = class {
             case 'u8': this._dataType = 'uint8'; break;
             case 'bf16': this._dataType = 'bfloat16'; break;
             case 'boolean': this._dataType = 'boolean'; break;
+            case 'f8_e4m3': this._dataType = 'float8e4m3'; break;
+            case 'f8_e5m2': this._dataType = 'float8e5m2'; break;
             case 'undef': this._dataType = '?'; break;
             default: throw new onednn.Error(`Unsupported tensor data type '${dataType}'.`);
         }


### PR DESCRIPTION
oneDNN now supports float8 data types.

https://github.com/oneapi-src/oneDNN/blob/a3b1a1481c3e1029093b3ab58ed124bb848d34dd/include/oneapi/dnnl/dnnl_common_types.h#L95-L100

This is to update onednn.js to parse the new data types.