### PR TITLE
Make dagre run faster with runLayout

### DIFF
--- a/source/dagre.js
+++ b/source/dagre.js
@@ -887,8 +887,10 @@ dagre.layout = (graph, layout) => {
                 }
             };
             const queue = g.children();
-            while (queue.length > 0) {
-                const v = queue.shift();
+            let qidx = 0;
+            while (qidx < queue.length) {
+                // NOTE revert to queue.shift() when V8 gets faster
+                const v = queue[qidx++];
                 const node = g.node(v).label;
                 if ('minRank' in node) {
                     node.borderLeft = [];
@@ -1240,8 +1242,10 @@ dagre.layout = (graph, layout) => {
                 if (maxRank !== undefined) {
                     const layers = Array.from(new Array(maxRank + 1), () => []);
                     const queue = nodes.sort((a, b) => a.label.rank - b.label.rank).map((node) => node.v).reverse();
-                    while (queue.length > 0) {
-                        const v = queue.shift();
+                    let qidx = 0;
+                    while (qidx < queue.length) {
+                        // NOTE revert to queue.shift() when V8 gets faster
+                        const v = queue[qidx++];
                         if (!visited.has(v)) {
                             visited.add(v);
                             const rank = g.node(v).label.rank;


### PR DESCRIPTION
This is a small hack to make dagre runLayout method run faster.