### PR TITLE
Mitigate crossings of connection lines

### DIFF
--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1432,6 +1432,27 @@ dagre.layout = (graph, layout) => {
                     ++j;
                 }
             }
+            // mitigate crossings of input connection lines
+            for (let i = 0; i < best.length - 2; i += 2) {
+                const layer0 = best[i];
+                const layer1 = best[i + 1];
+                const layer2 = best[i + 2];
+                for (let j = 0; j < layer2.length; ++j) {
+                    const node0 = g.nodes.get(layer2[j]);
+                    if (!node0.in || node0.in.length < 2) {
+                        continue;
+                    }
+                    for (let k = 0; k < node0.in.length - 1; ++k) {
+                        const node1d = node0.in[k].vNode;
+                        const node2d = node0.in[k + 1].vNode;
+                        const node1 = node1d.in[0].vNode;
+                        const node2 = node2d.in[0].vNode;
+                        if ((layer1.indexOf(node1d.v) < layer1.indexOf(node2d.v)) ^ (layer0.indexOf(node1.v) < layer0.indexOf(node2.v))) {
+                            exchange(layer1, node1d, node2d);
+                        }
+                    }
+                }
+            }
             assignOrder(g, best);
         };
 

--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1406,6 +1406,9 @@ dagre.layout = (graph, layout) => {
                         }
                         const node1d = node1.out[0].wNode;
                         const node2d = node2.out[0].wNode;
+                        if (node1d.out.length !== 1 || node2d.out.length !== 1) {
+                            continue;
+                        }
                         const node3 = node1d.out[0].wNode;
                         const node4 = node2d.out[0].wNode;
                         const idx3 = layer4.indexOf(node3.v);
@@ -1430,6 +1433,9 @@ dagre.layout = (graph, layout) => {
                     }
                     const node0u = node0.in[0].vNode;
                     const node1u = node1.in[0].vNode;
+                    if (node0u.in.length !== 1 || node1u.in.length !== 1) {
+                        continue;
+                    }
                     const node2 = node0u.in[0].vNode;
                     const node3 = node1u.in[0].vNode;
                     let idx0 = layer0.indexOf(node2.v);

--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1349,6 +1349,89 @@ dagre.layout = (graph, layout) => {
                     bestCC = cc;
                 }
             }
+            // Mitigate crossings
+            const exchange = (layer, node0, node1) => {
+                const idx0 = layer.indexOf(node0.v);
+                const idx1 = layer.indexOf(node1.v);
+                layer[idx1] = node0.v;
+                layer[idx0] = node1.v;
+            };
+            for (let i = 0; i < best.length - 4; i += 2) {
+                const layer0 = best[i];
+                const layer2 = best[i + 2];
+                const layer4 = best[i + 4];
+                if (layer2.length < 2 || layer4.length < 2) {
+                    continue;
+                }
+                const layer1 = best[i + 1];
+                const layer3 = best[i + 3];
+                for (let j = 0; j < layer0.length; ++j) {
+                    const node0 = g.nodes.get(layer0[j]);
+                    if (!node0.in || !node0.out || node0.out.length < 2) {
+                        continue;
+                    }
+                    for (let k = 0; k < node0.out.length - 1; ++k) {
+                        const node1u = node0.out[k].wNode;
+                        const node2u = node0.out[k + 1].wNode;
+                        const node1 = node1u.out[0].wNode;
+                        const node2 = node2u.out[0].wNode;
+                        if (node1.out.length !== 1 || node2.out.length !== 1) {
+                            continue;
+                        }
+                        const idx1 = layer2.indexOf(node1.v);
+                        const idx2 = layer2.indexOf(node2.v);
+                        if (idx1 + 1 !== idx2) {
+                            continue;
+                        }
+                        const node1d = node1.out[0].wNode;
+                        const node2d = node2.out[0].wNode;
+                        const node3 = node1d.out[0].wNode;
+                        const node4 = node2d.out[0].wNode;
+                        const idx3 = layer4.indexOf(node3.v);
+                        const idx4 = layer4.indexOf(node4.v);
+                        if (idx3 <= idx4) {
+                            continue;
+                        }
+                        exchange(layer1, node1u, node2u);
+                        exchange(layer2, node1, node2);
+                        exchange(layer3, node1d, node2d);
+                        ++k;
+                    }
+                }
+                for (let j = 0; j < layer2.length - 1; ++j) {
+                    const node0 = g.nodes.get(layer2[j]);
+                    if (!node0.in || !node0.out || node0.in.length !== 1 || node0.out.length !== 1) {
+                        continue;
+                    }
+                    const node1 = g.nodes.get(layer2[j + 1]);
+                    if (!node1.in || !node1.out || node1.in.length !== 1 || node1.out.length !== 1) {
+                        continue;
+                    }
+                    const node0u = node0.in[0].vNode;
+                    const node1u = node1.in[0].vNode;
+                    const node2 = node0u.in[0].vNode;
+                    const node3 = node1u.in[0].vNode;
+                    let idx0 = layer0.indexOf(node2.v);
+                    let idx1 = layer0.indexOf(node3.v);
+                    if (idx1 + 1 !== idx0) {
+                        continue;
+                    }
+                    const node0d = node0.out[0].wNode;
+                    const node1d = node1.out[0].wNode;
+                    idx0 = layer3.indexOf(node0d.v);
+                    idx1 = layer3.indexOf(node1d.v);
+                    if (idx0 + 1 !== idx1) {
+                        continue;
+                    }
+                    if (node0d.out[0].wNode !== node1d.out[0].wNode) {
+                        continue;
+                    }
+                    exchange(layer1, node0u, node1u);
+                    exchange(layer2, node0, node1);
+                    exchange(layer3, node0d, node1d);
+                    ++j;
+                }
+            }
             assignOrder(g, best);
         };
 

--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1356,6 +1356,27 @@ dagre.layout = (graph, layout) => {
                 layer[idx1] = node0.v;
                 layer[idx0] = node1.v;
             };
+            // mitigate crossings of input connection lines
+            for (let i = 0; i < best.length - 2; i += 2) {
+                const layer0 = best[i];
+                const layer1 = best[i + 1];
+                const layer2 = best[i + 2];
+                for (let j = 0; j < layer2.length; ++j) {
+                    const node0 = g.nodes.get(layer2[j]);
+                    if (!node0.in || node0.in.length < 2) {
+                        continue;
+                    }
+                    for (let k = 0; k < node0.in.length - 1; ++k) {
+                        const node1d = node0.in[k].vNode;
+                        const node2d = node0.in[k + 1].vNode;
+                        const node1 = node1d.in[0].vNode;
+                        const node2 = node2d.in[0].vNode;
+                        if ((layer1.indexOf(node1d.v) < layer1.indexOf(node2d.v)) ^ (layer0.indexOf(node1.v) < layer0.indexOf(node2.v))) {
+                            exchange(layer1, node1d, node2d);
+                        }
+                    }
+                }
+            }
             for (let i = 0; i < best.length - 4; i += 2) {
                 const layer0 = best[i];
                 const layer2 = best[i + 2];
@@ -1430,27 +1451,6 @@ dagre.layout = (graph, layout) => {
                     exchange(layer2, node0, node1);
                     exchange(layer3, node0d, node1d);
                     ++j;
-                }
-            }
-            // mitigate crossings of input connection lines
-            for (let i = 0; i < best.length - 2; i += 2) {
-                const layer0 = best[i];
-                const layer1 = best[i + 1];
-                const layer2 = best[i + 2];
-                for (let j = 0; j < layer2.length; ++j) {
-                    const node0 = g.nodes.get(layer2[j]);
-                    if (!node0.in || node0.in.length < 2) {
-                        continue;
-                    }
-                    for (let k = 0; k < node0.in.length - 1; ++k) {
-                        const node1d = node0.in[k].vNode;
-                        const node2d = node0.in[k + 1].vNode;
-                        const node1 = node1d.in[0].vNode;
-                        const node2 = node2d.in[0].vNode;
-                        if ((layer1.indexOf(node1d.v) < layer1.indexOf(node2d.v)) ^ (layer0.indexOf(node1.v) < layer0.indexOf(node2.v))) {
-                            exchange(layer1, node1d, node2d);
-                        }
-                    }
                 }
             }
             assignOrder(g, best);


### PR DESCRIPTION
This PR updates `order` function in `dagre.js` to mitigate crossings of connection lines.

<details>
<summary>yolov5n.onnx</summary>

[yolov5n.onnx](https://github.com/ultralytics/yolov5/releases/download/v6.0/yolov5n.onnx)

Before | After
--------|------------
![before](https://github.com/lutzroeder/netron/assets/1131125/228ae81b-9908-4704-a02c-3fcd4c4077ae) | ![after](https://github.com/lutzroeder/netron/assets/1131125/602646eb-32d0-46b8-8bf2-f6f395695cd0)

</details>

<details>
<summary>gpt2_Opset18.onnx</summary>

[gpt2_Opset18.onnx](https://media.githubusercontent.com/media/onnx/models/main/Generative_AI/skip/gpt2_Opset18_transformers/gpt2_Opset18.onnx)

Before | After
--------|------------
![before](https://github.com/lutzroeder/netron/assets/1131125/4f5d6600-27a7-4a74-b756-897abdd990b4) | ![after](https://github.com/lutzroeder/netron/assets/1131125/db59de41-eeec-4ac7-86d6-25f680913a96)
![before](https://github.com/lutzroeder/netron/assets/1131125/a6b22cc9-ac27-4c83-9941-052823df4e20) | ![after](https://github.com/lutzroeder/netron/assets/1131125/36929f2c-5c3b-4837-a998-3cf86c7d598f)

</details>

<details>
<summary>saved_model.pbtxt</summary>

[sample.zip](https://github.com/tensorflow/tensorflow/files/917065/sample.zip)

Before | After
--------|------------
![before](https://github.com/lutzroeder/netron/assets/1131125/4bc2fa89-86b3-4148-b088-debaad964c4a) | ![after](https://github.com/lutzroeder/netron/assets/1131125/29ebac64-bd00-4e81-b687-1158be1de652)

</details>

<details>
<summary>retinanet_resnet50_fpn_v2_Opset18.onnx</summary>

[retinanet_resnet50_fpn_v2_Opset18.onnx](https://media.githubusercontent.com/media/onnx/models/main/Computer_Vision/retinanet_resnet50_fpn_v2_Opset18_torchvision/retinanet_resnet50_fpn_v2_Opset18.onnx)

Before | After
--------|------------
![before](https://github.com/lutzroeder/netron/assets/1131125/629255f6-c656-4020-9ab1-9b611935bcc6) | ![after](https://github.com/lutzroeder/netron/assets/1131125/5eef4617-c45e-42f4-9321-abcbc6d91737)
![before](https://github.com/lutzroeder/netron/assets/1131125/b6fbd770-805f-4583-bcc8-9fb68e602e69) | ![after](https://github.com/lutzroeder/netron/assets/1131125/23185671-1e52-4084-8077-83c96a2ba24e)

</details>

The crossings around the yellow rectangles are cleared. But it's difficult to reduce the crossings around the blue rectangles. Perhaps they can be improved later.

The change might not work well with other models so let me know if you find any problems.
