### PR TITLE
Speed-up dagre.Graph

### DIFF
--- a/source/dagre.js
+++ b/source/dagre.js
@@ -2247,7 +2247,7 @@ dagre.Graph = class {
             edge.wNode = wNode;
             edge.vNode = vNode;
             const incrementOrInitEntry = (map, k) => {
-                let v = map.has(k) ? map.get(k) : 0;
+                const v = map.has(k) ? map.get(k) : 0;
                 map.set(k, v + 1);
             };
             incrementOrInitEntry(wNode.predecessors, v);
@@ -2265,7 +2265,7 @@ dagre.Graph = class {
         const vNode = edge.vNode;
         if (wNode.predecessors.has(v)) {
             const tmp = wNode.predecessors.get(v);
-            if (tmp == 1) {
+            if (tmp === 1) {
                 wNode.predecessors.delete(v);
             } else {
                 wNode.predecessors.set(v, tmp - 1);
@@ -2273,7 +2273,7 @@ dagre.Graph = class {
         }
         if (vNode.successors.has(w)) {
             const tmp = vNode.successors.get(w);
-            if (tmp == 1) {
+            if (tmp === 1) {
                 vNode.successors.delete(w);
             } else {
                 vNode.successors.set(w, tmp - 1);


### PR DESCRIPTION
I've noticed that using `Map` instead of `Object` for node's predecessors and successors speeds-up the layouting time.

model | Worker before (ddd5f6f8a32791de7a6d41da6ad5f1537e369aa9) [ms] | Worker after [ms]
------|-----------:|-----------------:
retinanet_resnet50_fpn_v2_Opset18.onnx | 1984 | 1073
yolov9-c.onnx | 1045 | 697
yolov5n.onnx | 184 | 145

(CPU : AMD Ryzen 9 7900X)
