### PR TITLE
Show "const input" layer as regular layer.

### DIFF
--- a/source/hailo.js
+++ b/source/hailo.js
@@ -70,7 +70,6 @@ hailo.Graph = class {
         });
         for (const layer of layers) {
             switch (layer.type) {
-                case 'const_input':
                 case 'input_layer': {
                     for (let i = 0; i < layer.output.length; i++) {
                         const shape = Array.isArray(layer.output_shapes) && layer.output_shapes.length > 0 ? layer.output_shapes[0] : null;


### PR DESCRIPTION
Fixed "const_input" layer type representation. Now it's not an input layer type but regular layer with all visible attributes.

<img width="926" alt="image" src="https://github.com/lutzroeder/netron/assets/81561557/d6c3b4ac-42a0-450b-9a0c-1909030b14d3">
