### PR TITLE
Add support for .har files extension.

### DIFF
--- a/source/base.js
+++ b/source/base.js
@@ -1246,7 +1246,7 @@ base.Metadata = class {
             'gguf',
             'hd5', 'hdf5', 'keras',
             'tfl', 'circle', 'lite',
-            'mlnet', 'mar', 'maxviz', 'meta', 'nn', 'ngf', 'hn',
+            'mlnet', 'mar', 'maxviz', 'meta', 'nn', 'ngf', 'hn', 'har',
             'param', 'params',
             'paddle', 'pdiparams', 'pdmodel', 'pdopt', 'pdparams', 'nb',
             'pkl', 'joblib', 'safetensors',


### PR DESCRIPTION
After some previous changes the netron application stopped to open .har files because this file extension isn't present in the official supported extensions list. Now it is able to open .har files also.