### PR TITLE
Make graph grabbable on pointer down event

### DIFF
--- a/source/view.js
+++ b/source/view.js
@@ -448,9 +448,6 @@ view.View = class {
             return;
         }
         const container = this._element('graph');
-        if (e.target === container) {
-            return;
-        }
         e.target.setPointerCapture(e.pointerId);
         this._mousePosition = {
             left: container.scrollLeft,


### PR DESCRIPTION
When a loaded model isn't wide, the displayed width of the `background` element can be narrower than the window width, in this case, dragging doesn't start if outside of the `background` element is pressed. But this is non-intuitive to users since the `background` element is (normally) invisible. This PR updates `view.View` class's `_pointerDownHandler` method to avoid it.

Before: ![before](https://github.com/user-attachments/assets/cce8d0ba-a79b-48f8-b145-293f36c7ccd6)

After: ![after](https://github.com/user-attachments/assets/a0b5d7a0-f4a0-42ae-b2eb-c986a8810830)
