### PR TITLE
Support bfloat16 dtype for RKNN models

### DIFF
--- a/source/rknn.js
+++ b/source/rknn.js
@@ -173,7 +173,7 @@ rknn.Graph = class {
             }
             case 'flatbuffers': {
                 const graph = obj;
-                const dataTypes = ['unk0', 'int32', '?', 'int8', '?', 'int16', 'float32', 'int64', '?', '?', 'float16', '?', '?', 'unk13', '?', '?', '?'];
+                const dataTypes = ['unk0', 'int32', '?', 'int8', '?', 'int16', 'float32', 'int64', '?', '?', 'float16', '?', '?', 'unk13', '?', '?', 'bfloat16'];
                 const args = graph.tensors.map((tensor) => {
                     const shape = new rknn.TensorShape(Array.from(tensor.shape));
                     const dataType = tensor.data_type < dataTypes.length ? dataTypes[tensor.data_type] : '?';


### PR DESCRIPTION
Solve the error "Unsupported tensor data type '16'." on some models.

Example model: [edge_sam_3x_encoder.onnx.zip](https://github.com/user-attachments/files/16455190/edge_sam_3x_encoder.onnx.zip)

![image](https://github.com/user-attachments/assets/68b6b20c-1cca-4a94-8c90-86e17ef9280f)