### PR TITLE
Reduce crossings of connection lines

### DIFF
--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1393,7 +1393,7 @@ dagre.layout = (nodes, edges, layout, state) => {
             for (let j = 0; j < layer2.length; ++j) {
                 const node0 = g.nodes.get(layer2[j]);
                 if (node0.in && node0.in.length >= 2) {
-                    if (node0.in.length == 2) {
+                    if (node0.in.length === 2) {
                         const node1d = node0.in[0].vNode;
                         const node2d = node0.in[1].vNode;
                         const node1 = node1d.in[0].vNode;
@@ -1401,8 +1401,8 @@ dagre.layout = (nodes, edges, layout, state) => {
                         if ((layer1.indexOf(node1d.v) < layer1.indexOf(node2d.v)) ^ (layer0.indexOf(node1.v) < layer0.indexOf(node2.v))) {
                             exchange(layer1, node1d, node2d);
                         }
-                    }else {
-                        let indexes1 = [];
+                    } else {
+                        const indexes1 = [];
                         for (let k = 0; k < node0.in.length; ++k) {
                             const node1 = node0.in[k].vNode;
                             const node2 = node1.in[0].vNode;

--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1376,6 +1376,20 @@ dagre.layout = (nodes, edges, layout, state) => {
             const layer0 = best[i];
             const layer1 = best[i + 1];
             const layer2 = best[i + 2];
+            for (let j = 0; j < layer0.length; ++j) {
+                const node0 = g.nodes.get(layer0[j]);
+                if (node0.out && node0.out.length >= 2) {
+                    for (let k = 0; k < node0.out.length - 1; ++k) {
+                        const node1d = node0.out[k].wNode;
+                        const node2d = node0.out[k + 1].wNode;
+                        const node1 = node1d.out[0].wNode;
+                        const node2 = node2d.out[0].wNode;
+                        if ((layer1.indexOf(node1d.v) < layer1.indexOf(node2d.v)) ^ (layer2.indexOf(node1.v) < layer2.indexOf(node2.v))) {
+                            exchange(layer1, node1d, node2d);
+                        }
+                    }
+                }
+            }
             for (let j = 0; j < layer2.length; ++j) {
                 const node0 = g.nodes.get(layer2[j]);
                 if (node0.in && node0.in.length >= 2) {

--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1402,7 +1402,6 @@ dagre.layout = (nodes, edges, layout, state) => {
                             exchange(layer1, node1d, node2d);
                         }
                     }else {
-                        let indexes = [];
                         let indexes1 = [];
                         for (let k = 0; k < node0.in.length; ++k) {
                             const node1 = node0.in[k].vNode;
@@ -1410,17 +1409,12 @@ dagre.layout = (nodes, edges, layout, state) => {
                             const idx0 = layer0.indexOf(node2.v);
                             const idx1 = layer1.indexOf(node1.v);
                             node0.in[k].idx0 = idx0;
-                            indexes.push({
-                                "v" : node1.v,
-                                "idx0" : idx0,
-                            });
                             indexes1.push(idx1);
                         }
                         node0.in.sort((a, b) => a.idx0 - b.idx0);
-                        indexes.sort((a, b) => a.idx0 - b.idx0);
                         indexes1.sort((a, b) => a - b);
                         for (let k = 0; k < indexes1.length; ++k) {
-                            layer1[indexes1[k]] = indexes[k].v;
+                            layer1[indexes1[k]] = node0.in[k].v;
                         }
                     }
                 }

--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1393,13 +1393,34 @@ dagre.layout = (nodes, edges, layout, state) => {
             for (let j = 0; j < layer2.length; ++j) {
                 const node0 = g.nodes.get(layer2[j]);
                 if (node0.in && node0.in.length >= 2) {
-                    for (let k = 0; k < node0.in.length - 1; ++k) {
-                        const node1d = node0.in[k].vNode;
-                        const node2d = node0.in[k + 1].vNode;
+                    if (node0.in.length == 2) {
+                        const node1d = node0.in[0].vNode;
+                        const node2d = node0.in[1].vNode;
                         const node1 = node1d.in[0].vNode;
                         const node2 = node2d.in[0].vNode;
                         if ((layer1.indexOf(node1d.v) < layer1.indexOf(node2d.v)) ^ (layer0.indexOf(node1.v) < layer0.indexOf(node2.v))) {
                             exchange(layer1, node1d, node2d);
+                        }
+                    }else {
+                        let indexes = [];
+                        let indexes1 = [];
+                        for (let k = 0; k < node0.in.length; ++k) {
+                            const node1 = node0.in[k].vNode;
+                            const node2 = node1.in[0].vNode;
+                            const idx0 = layer0.indexOf(node2.v);
+                            const idx1 = layer1.indexOf(node1.v);
+                            node0.in[k].idx0 = idx0;
+                            indexes.push({
+                                "v" : node1.v,
+                                "idx0" : idx0,
+                            });
+                            indexes1.push(idx1);
+                        }
+                        node0.in.sort((a, b) => a.idx0 - b.idx0);
+                        indexes.sort((a, b) => a.idx0 - b.idx0);
+                        indexes1.sort((a, b) => a - b);
+                        for (let k = 0; k < indexes1.length; ++k) {
+                            layer1[indexes1[k]] = indexes[k].v;
                         }
                     }
                 }


### PR DESCRIPTION
This PR is a sequel of #1261. 

The crossings around the yellow rectangles are cleared. There was a leftover in the crossing reduction code.

<details><summary>EfficientDet-d0.onnx</summary>

Left : Before
Right : Ater

![image](https://github.com/user-attachments/assets/5c2f647c-5673-4d0d-8632-3f14f364bedc)

</details>

<details><summary>saved_model.pbtxt</summary>

Left : Before
Right : Ater

![image](https://github.com/user-attachments/assets/918b1132-f25e-48df-becd-5db7de3ff7d0)

</details>


<details><summary>gpt-j-6B-int8-static.onnx</summary>

Left : Before
Right : Ater

![image](https://github.com/user-attachments/assets/6575a339-aa02-40ee-9f12-a6af2c9897ed)


</details>

