### PR TITLE
Reduce crossings of connection lines

### DIFF
--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1383,7 +1383,7 @@ dagre.layout = (nodes, edges, layout, state) => {
                         const dir = calcDir(idx0, idx1);
                         dirTotal |= dir;
                         if (idx0 === idx1
-                            || Math.abs(idx0 - idx1) != 1
+                            || Math.abs(idx0 - idx1) !== 1
                             || n0.in.length !== 1
                             || n1.in.length !== 1
                             || n0.out.length !== 1


### PR DESCRIPTION
This PR is a sequel of #1327 and #1261.

The crossings around the yellow rectangles are cleared.

<details><summary>saved_model.pbtxt</summary>

Left : Before
Right : Ater

![image](https://github.com/user-attachments/assets/9e59456c-8c2d-4abf-a2b2-9ec4647728c4)

![image](https://github.com/user-attachments/assets/a757586b-fa33-41ab-8dbb-4eab334a76a6)

</details>

<details><summary>gpt-j-6B-int8-static.onnx</summary>

Left : Before
Right : Ater

![image](https://github.com/user-attachments/assets/da33fff3-e6f7-4dbf-a588-4c6287c83837)

</details>

<details><summary>t5-encoder-12.onnx</summary>

Left : Before
Right : Ater

![image](https://github.com/user-attachments/assets/9115906c-594e-40d6-9359-dfc435249fc9)

![image](https://github.com/user-attachments/assets/0f398f80-5ce4-4ebe-8060-8839f10760c8)

</details>


<details><summary>retinanet_resnet50_fpn_v2_Opset18.onnx</summary>

Left : Before
Right : Ater

![image](https://github.com/user-attachments/assets/8d24521c-3df6-47a0-b499-3240ad4104ad)

</details>
