### PR TITLE
Restore scroll position and zoom when going back from function

### DIFF
--- a/source/view.js
+++ b/source/view.js
@@ -858,11 +858,11 @@ view.View = class {
             canvas.setAttribute('viewBox', `0 0 ${width} ${height}`);
             canvas.setAttribute('width', width);
             canvas.setAttribute('height', height);
-            this._zoom = ('zoom' in this._stack[0]) ? this._stack[0].zoom : 1;
+            this._zoom = (this._stack && this._stack.length > 0 && 'zoom' in this._stack[0]) ? this._stack[0].zoom : 1;
             this._updateZoom(this._zoom);
             const container = this._element('graph');
             if (elements && elements.length > 0) {
-                const e = ('nodeElementId' in this._stack[0]) ? canvas.getElementById(this._stack[0].nodeElementId) : null;
+                const e = (this._stack && this._stack.length > 0 && 'nodeElementId' in this._stack[0]) ? canvas.getElementById(this._stack[0].nodeElementId) : null;
                 if (e) {
                     this.scrollTo([e], 'instant');
                 } else {

--- a/source/view.js
+++ b/source/view.js
@@ -819,7 +819,6 @@ view.View = class {
             graph_skip: 0
         });
         const viewGraph = new view.Graph(this, this._host, model, options, groups);
-        view.Node.counter = 0;
         viewGraph.add(graph, signature);
         // Workaround for Safari background drag/zoom issue:
         // https://stackoverflow.com/questions/40887193/d3-js-zoom-is-not-working-with-mousewheel-in-safari


### PR DESCRIPTION
To restore scroll position and zoom when going back from function, several changes are added.

- An additional optional parameter `behavior` is added to `scrollTo` method of `view.View` class to customize scrolling behavior. 'smooth' is used originally but IMO, 'instant' is suited in this case.
  - https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo
- An additional optional parameter `nodeElementId` is added to `pushGraph` method of `view.View` class to save target node's element id.
- Added a line of code to reset the class variable `view.Node.counter` to 0 in `renderGraph` method of `view.View` class.
  - The counter variable is used in a constructor method of `view.Node` class. Without the resetting, different identifiers are assigned to nameless nodes when they are recreated so that negates identifying a target element to scroll to.

Tested with the following models.
- `Clara_DenseNet_dynamo.onnx` in [Clara_DenseNet_dynamo.zip](https://github.com/lutzroeder/netron/files/14216336/Clara_DenseNet_dynamo.zip) (linked in https://github.com/lutzroeder/netron/issues/1225#issue-2126336662, contains a lot of nested function nodes)
- [retinanet_resnet50_fpn_v2_Opset18.onnx](https://media.githubusercontent.com/media/onnx/models/main/Computer_Vision/retinanet_resnet50_fpn_v2_Opset18_torchvision/retinanet_resnet50_fpn_v2_Opset18.onnx) (contains nameless function nodes)

#1334 is related.