### PR TITLE
dagre.layout minor performance optimization

### DIFF
--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1400,14 +1400,10 @@ dagre.layout = (nodes, edges, layout, state) => {
                                     const idx2 = layer2.indexOf(g.node(layer1[idx0]).in[0].v);
                                     const idx3 = layer2.indexOf(g.node(layer1[idx1]).in[0].v);
                                     if (calcDir(idx0, idx1) !== topDir) {
-                                        const tmp = layer1[idx1];
-                                        layer1[idx1] = layer1[idx0];
-                                        layer1[idx0] = tmp;
+                                        [layer1[idx0], layer1[idx1]] = [layer1[idx1], layer1[idx0]];
                                     }
                                     if (calcDir(idx2, idx3) !== topDir) {
-                                        const tmp = layer2[idx3];
-                                        layer2[idx3] = layer2[idx2];
-                                        layer2[idx2] = tmp;
+                                        [layer2[idx2], layer2[idx3]] = [layer2[idx3], layer2[idx2]];
                                     }
                                     l += 2;
                                 }
@@ -1610,9 +1606,7 @@ dagre.layout = (nodes, edges, layout, state) => {
         }
         if (rankDir === 'lr' || rankDir === 'rl') {
             const swapXYOne = (attrs) => {
-                const x = attrs.x;
-                attrs.x = attrs.y;
-                attrs.y = x;
+                [attrs.x, attrs.y] = [attrs.y, attrs.x];
             };
             for (const node of g.nodes.values()) {
                 swapXYOne(node.label);
@@ -1633,9 +1627,7 @@ dagre.layout = (nodes, edges, layout, state) => {
     const position = (g, state, layout) => {
         const addConflict = (conflicts, v, w) => {
             if (v > w) {
-                const tmp = v;
-                v = w;
-                w = tmp;
+                [v, w] = [w, v];
             }
             let conflictsV = conflicts[v];
             if (!conflictsV) {
@@ -1646,9 +1638,7 @@ dagre.layout = (nodes, edges, layout, state) => {
         };
         const hasConflict = (conflicts, v, w) => {
             if (v > w) {
-                const tmp = v;
-                v = w;
-                w = tmp;
+                [v, w] = [w, v];
             }
             return conflicts[v] && conflicts[v].has(w);
         };
@@ -2373,9 +2363,7 @@ dagre.Graph = class {
             edge.label = label;
         } else {
             if (!this.directed && v > w) {
-                const tmp = v;
-                v = w;
-                w = tmp;
+                [v, w] = [w, v];
             }
             const edge = { label, v, w, name, key, vNode: null, wNode: null };
             this.edges.set(key, edge);

--- a/source/dagre.js
+++ b/source/dagre.js
@@ -2330,9 +2330,8 @@ dagre.Graph = class {
             return this._children.get(v === undefined ? '\x00' : v).size > 0;
         } else if (v === undefined) {
             return this.nodes.size > 0;
-        } else {
-            return false;
         }
+        return false;
     }
 
     predecessors(v) {

--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1199,7 +1199,7 @@ dagre.layout = (nodes, edges, layout, state) => {
         // the order of its nodes.
         const initOrder = (g) => {
             const visited = new Set();
-            const nodes = Array.from(g.nodes.values()).filter((node) => Array.from(g.children(node.v)).length === 0);
+            const nodes = Array.from(g.nodes.values()).filter((node) => g.children(node.v).next().done);
             let maxRank = -1;
             for (const node of nodes) {
                 const rank = node.label.rank;
@@ -2014,7 +2014,7 @@ dagre.layout = (nodes, edges, layout, state) => {
     const removeBorderNodes = (g) => {
         for (const node of g.nodes.values()) {
             const v = node.v;
-            if (Array.from(g.children(v)).length) {
+            if (!g.children(v).next().done) {
                 const label = node.label;
                 const t = g.node(label.borderTop).label;
                 const b = g.node(label.borderBottom).label;
@@ -2200,7 +2200,7 @@ dagre.layout = (nodes, edges, layout, state) => {
         const label = g.node(node.v).label;
         node.x = label.x;
         node.y = label.y;
-        if (Array.from(g.children(node.v)).length) {
+        if (!g.children(node.v).next().done) {
             node.width = label.width;
             node.height = label.height;
         }

--- a/source/dagre.js
+++ b/source/dagre.js
@@ -45,7 +45,7 @@ dagre.layout = (nodes, edges, layout, state) => {
         const graph = new dagre.Graph(true, false);
         for (const node of g.nodes.values()) {
             const v = node.v;
-            if (g.children(v).next().done) {
+            if (!g.hasChildren(v)) {
                 graph.setNode(v, node.label);
             }
         }
@@ -1051,7 +1051,7 @@ dagre.layout = (nodes, edges, layout, state) => {
             const movable = bl ? Array.from(g.children(v)).filter((w) => w !== bl && w !== br) : g.children(v);
             const barycenters = barycenter(g, movable);
             for (const entry of barycenters) {
-                if (!g.children(entry.v).next().done) {
+                if (g.hasChildren(entry.v)) {
                     const result = sortSubgraph(g, entry.v, cg, biasRight);
                     subgraphs[entry.v] = result;
                     if ('barycenter' in result) {
@@ -2014,7 +2014,7 @@ dagre.layout = (nodes, edges, layout, state) => {
     const removeBorderNodes = (g) => {
         for (const node of g.nodes.values()) {
             const v = node.v;
-            if (!g.children(v).next().done) {
+            if (g.hasChildren(v)) {
                 const label = node.label;
                 const t = g.node(label.borderTop).label;
                 const b = g.node(label.borderBottom).label;
@@ -2200,7 +2200,7 @@ dagre.layout = (nodes, edges, layout, state) => {
         const label = g.node(node.v).label;
         node.x = label.x;
         node.y = label.y;
-        if (!g.children(node.v).next().done) {
+        if (g.hasChildren(node.v)) {
             node.width = label.width;
             node.height = label.height;
         }
@@ -2323,6 +2323,16 @@ dagre.Graph = class {
             return [];
         }
         return null;
+    }
+
+    hasChildren(v) {
+        if (this.compound) {
+            return this._children.get(v === undefined ? '\x00' : v).size > 0;
+        } else if (v === undefined) {
+            return this.nodes.size > 0;
+        } else {
+            return false;
+        }
     }
 
     predecessors(v) {

--- a/source/grapher.js
+++ b/source/grapher.js
@@ -9,9 +9,9 @@ grapher.Graph = class {
         this._edges = new Map();
         this._focusable = new Map();
         this._focused = [];
-        this._children = {};
-        this._children['\x00'] = {};
-        this._parent = {};
+        this._children = new Map();
+        this._children.set('\x00', new Map());
+        this._parent = new Map();
     }
 
     setNode(node) {
@@ -22,9 +22,9 @@ grapher.Graph = class {
         } else {
             this._nodes.set(key, { v: key, label: node });
             if (this._compound) {
-                this._parent[key] = '\x00';
-                this._children[key] = {};
-                this._children['\x00'][key] = true;
+                this._parent.set(key, '\x00');
+                this._children.set(key, new Map());
+                this._children.get('\x00').set(key, true);
             }
         }
     }
@@ -52,9 +52,9 @@ grapher.Graph = class {
                 throw new Error(`Setting ${parent} as parent of ${node} would create a cycle`);
             }
         }
-        delete this._children[this._parent[node]][node];
-        this._parent[node] = parent;
-        this._children[parent][node] = true;
+        this._children.get(this._parent.get(node)).delete(node);
+        this._parent.set(node, parent);
+        this._children.get(parent).set(node, true);
         return this;
     }
 
@@ -80,7 +80,7 @@ grapher.Graph = class {
 
     parent(key) {
         if (this._compound) {
-            const parent = this._parent[key];
+            const parent = this._parent.get(key);
             if (parent !== '\x00') {
                 return parent;
             }
@@ -91,9 +91,9 @@ grapher.Graph = class {
     children(key) {
         key = key === undefined ? '\x00' : key;
         if (this._compound) {
-            const children = this._children[key];
+            const children = this._children.get(key);
             if (children) {
-                return Object.keys(children);
+                return Array.from(children.keys());
             }
         } else if (key === '\x00') {
             return this.nodes.keys();

--- a/source/tvm.js
+++ b/source/tvm.js
@@ -178,7 +178,9 @@ tvm.Graph = class {
                 blocks.get(nodeName).params.push({ name: argumentName, id: key });
                 values.map(key, null, tensors.get(key));
             }
-            this.nodes = blocks.values().map((block) => new tvm.Node(metadata, block, new Map(), values));
+            for (const block of blocks.values()) {
+                this.nodes.push(new tvm.Node(metadata, block, new Map(), values));
+            }
         }
     }
 };


### PR DESCRIPTION
I checked speed difference using `npm run test measure` command. Compared to current main (3bf0ac7bf97b7446f2aa1b5c4a4eab4efcc62670), the `render:` line changed from 68.26 to 60.81. So I suppose there's minor performance improvement with this change.

<details><summary>npm run test measure log</summary>

```
# after
download:   0.07
load:      39.96
validate:  56.14
render:    60.81
total:    156.92

# before
download:   0.08
load:      42.89
validate:  60.29
render:    68.26
total:    171.43
```

</details>
