### PR TITLE
Use Element: replaceChildren() method to remove all child nodes.

### DIFF
--- a/source/view.js
+++ b/source/view.js
@@ -1513,7 +1513,7 @@ view.Menu = class {
     }
 
     _rebuild() {
-        this._element.innerHTML = '';
+        this._element.replaceChildren();
         const root = this._root[this._root.length - 1];
         for (const group of root.items) {
             const container = this._document.createElement('div');
@@ -2451,7 +2451,7 @@ view.Sidebar = class {
         sidebar.addEventListener('transitionend', (event) => {
             if (event.propertyName === 'opacity' && sidebar.style.opacity === '0') {
                 const content = this._element('sidebar-content');
-                content.innerHTML = '';
+                content.innerHTML.replaceChildren();
             }
         });
     }
@@ -2509,12 +2509,12 @@ view.Sidebar = class {
             if (typeof entry.content === 'string') {
                 content.innerHTML = entry.element;
             } else if (entry.element instanceof Array) {
-                content.innerHTML = '';
+                content.replaceChildren();
                 for (const element of entry.element) {
                     content.appendChild(element);
                 }
             } else {
-                content.innerHTML = '';
+                content.replaceChildren();
                 content.appendChild(entry.element);
             }
             sidebar.style.width = 'min(calc(100% * 0.6), 42em)';
@@ -3916,7 +3916,7 @@ view.FindSidebar = class extends view.Control {
     }
 
     _update() {
-        this._content.innerHTML = '';
+        this._content.replaceChildren();
         try {
             this._clear();
             const inputs = this._signature ? this._signature.inputs : this._graph.inputs;
@@ -4014,6 +4014,7 @@ view.FindSidebar = class extends view.Control {
         }
         this._table.clear();
         this._focused.clear();
+        this._content.replaceChildren();
     }
 
     error(error, fatal) {

--- a/source/view.js
+++ b/source/view.js
@@ -4025,8 +4025,7 @@ view.FindSidebar = class extends view.Control {
         }
         this._table.clear();
         this._focused.clear();
-        //this._content.replaceChildren();
-        replaceChildren.call(this._content);
+        this._content.replaceChildren();
     }
 
     error(error, fatal) {

--- a/source/view.js
+++ b/source/view.js
@@ -15,6 +15,17 @@ const view = {};
 const markdown = {};
 const metrics = {};
 
+// Polyfills
+function replaceChildren(...children) {
+    while (this.lastChild) {
+        this.removeChild(this.lastChild);
+    }
+    for (const child of children) {
+        this.appendChild(child);
+    }
+}
+Element.prototype.replaceChildren ||= replaceChildren;
+
 view.View = class {
 
     constructor(host) {
@@ -4014,7 +4025,8 @@ view.FindSidebar = class extends view.Control {
         }
         this._table.clear();
         this._focused.clear();
-        this._content.replaceChildren();
+        //this._content.replaceChildren();
+        replaceChildren.call(this._content);
     }
 
     error(error, fatal) {

--- a/source/view.js
+++ b/source/view.js
@@ -3766,15 +3766,6 @@ view.FindSidebar = class extends view.Control {
     }
 
     focus(state) {
-        this._state = state || this._state;
-        this._query.focus();
-        this._query.value = '';
-        this._query.value = this._state.query;
-        for (const [name, toggle] of Object.entries(this._toggles)) {
-            toggle.checkbox.checked = this._state[name];
-            toggle.element.setAttribute('title', this._state[name] ? toggle.hide : toggle.show);
-        }
-        this._update();
     }
 
     _clear() {
@@ -4017,6 +4008,17 @@ view.FindSidebar = class extends view.Control {
 
     get element() {
         return [this._search, this._content];
+    }
+
+    activate() {
+        this._query.focus();
+        this._query.value = '';
+        this._query.value = this._state.query;
+        for (const [name, toggle] of Object.entries(this._toggles)) {
+            toggle.checkbox.checked = this._state[name];
+            toggle.element.setAttribute('title', this._state[name] ? toggle.hide : toggle.show);
+        }
+        this._update();
     }
 
     deactivate() {

--- a/source/view.js
+++ b/source/view.js
@@ -2462,7 +2462,7 @@ view.Sidebar = class {
         sidebar.addEventListener('transitionend', (event) => {
             if (event.propertyName === 'opacity' && sidebar.style.opacity === '0') {
                 const content = this._element('sidebar-content');
-                content.innerHTML.replaceChildren();
+                content.replaceChildren();
             }
         });
     }


### PR DESCRIPTION
This PR replaces `innerHTML = ''` with `replaceChildren()` to remove all child nodes.

https://stackoverflow.com/a/65413839
https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren

`view.FindSidebar.deactivate` is also updated in the hope of resolving the problem reported in #1358. Although the change doesn't solve the problem, closing the sidebar gets faster.

<details><summary>recording</summary>

[efficientdet-d3.onnx](https://github.com/phantrdat/onnx-efficientdet/blob/5efe7b1eb45d69f7ca4eef1022540aa8a2024ae8/efficientdet-d3.onnx) file is used.

![lifespan](https://github.com/user-attachments/assets/0dfc800c-01ab-4f63-bb6a-cc046873ddf9)

</details>
