### PR TITLE
Reduce time to change cursor

### DIFF
--- a/source/view.js
+++ b/source/view.js
@@ -465,7 +465,7 @@ view.View = class {
             x: e.clientX,
             y: e.clientY
         };
-        container.style.cursor = 'grabbing';
+        e.target.style.cursor = 'grabbing';
         e.preventDefault();
         e.stopImmediatePropagation();
         const pointerMoveHandler = (e) => {
@@ -488,7 +488,7 @@ view.View = class {
         };
         const pointerUpHandler = (e) => {
             e.target.releasePointerCapture(e.pointerId);
-            container.style.removeProperty('cursor');
+            e.target.style.removeProperty('cursor');
             container.removeEventListener('pointerup', pointerUpHandler);
             container.removeEventListener('pointermove', pointerMoveHandler);
             if (this._mousePosition && this._mousePosition.moved) {


### PR DESCRIPTION
When an element has large number of descendant elements, changing its style cusor takes some time on Chromium because of style recalculations. https://issues.chromium.org/issues/40493007

This becomes an issue because Netron changes mouse cursor before and after of panning the graph.

The original code changes container's style.cusor but it's slow when the container has lots of descendant elements.

This can be confirmed with models like [efficientdet-d3.onnx](https://github.com/phantrdat/onnx-efficientdet/blob/5efe7b1eb45d69f7ca4eef1022540aa8a2024ae8/efficientdet-d3.onnx) file. The slow response of pointerdown (due to changing mouse cursor) is quite obvious with not very fast computers such as Rasberry Pi 5.

#1013 is related.