### PR TITLE
URL parameter "/?file_path=" added to load local model files

### DIFF
--- a/source/__init__.py
+++ b/source/__init__.py
@@ -24,6 +24,8 @@ def main():
     parser.add_argument('--verbosity',
         metavar='LEVEL', help='output verbosity (quiet, default, debug)',
         choices=[ 'quiet', 'default', 'debug', '0', '1', '2' ], default='default')
+    parser.add_argument('--allow-local-files',
+        help='Allows serving local files', action='store_true')
     parser.add_argument('--version', help="print version", action='store_true')
     args = parser.parse_args()
     if args.file and not os.path.exists(args.file):
@@ -33,7 +35,8 @@ def main():
         print(__version__)
         sys.exit(0)
     address = (args.host, args.port) if args.host else args.port if args.port else None
-    start(args.file, address=address, browse=args.browse, verbosity=args.verbosity)
+    start(args.file, address=address, browse=args.browse,
+       verbosity=args.verbosity, allow_local_files=args.allow_local_files)
     wait()
     sys.exit(0)
 


### PR DESCRIPTION
Hello!

I've been working with Netron for some time and there's a feature that I was willing to add: loading local model files, hosted on the server, using an URL parameter.
This is similar as the currently supported `/?url` parameter, allowing us to load a model file from the Internet. The `/?file_path=` is just as the same but tries to load it from the server local files instead.
By default, this feature is disabled (eg. no file will be accessed on the server) to keep the current Netron behavior. This can be enabled using a new parameter called `--allow-local-files` when starting the server.

At the moment, loading a local file on Netron requires a manual action (drag/drop or a click on the "Load model" button). Using an URL parameter instead allows scripts to automatically load them on Netron, this is the main benefit of my PR.