### PR TITLE
[Fix] electron version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     },
     "devDependencies": {
         "@electron/notarize": "2.5.0",
-        "electron": "33.0.2",
+        "electron": "33.0.1",
         "electron-builder": "25.1.8",
         "eslint": "9.14.0"
     },


### PR DESCRIPTION
`npm install` failed with `electron@33.0.2` : https://github.com/electron/electron/issues/44529

- Netron app and version: dev version
- OS and browser version: Ubuntu 22.04.3 LTS

``` shell

npm http fetch POST 200 https://mirrors.cloud.tencent.com/npm/-/npm/v1/security/advisories/bulk 1138ms
npm warn deprecated @npmcli/move-file@2.0.1: This functionality has been moved to @npmcli/fs
npm info run electron@33.0.2 postinstall node_modules/electron node install.js
npm info run electron@33.0.2 postinstall { code: 1, signal: null }
npm verbose stack Error: command failed
npm verbose stack     at promiseSpawn (/home/shun/.nvm/versions/node/v22.11.0/lib/node_modules/npm/node_modules/@npmcli/promise-spawn/lib/index.js:22:22)
npm verbose stack     at spawnWithShell (/home/shun/.nvm/versions/node/v22.11.0/lib/node_modules/npm/node_modules/@npmcli/promise-spawn/lib/index.js:124:10)
npm verbose stack     at promiseSpawn (/home/shun/.nvm/versions/node/v22.11.0/lib/node_modules/npm/node_modules/@npmcli/promise-spawn/lib/index.js:12:12)
npm verbose stack     at runScriptPkg (/home/shun/.nvm/versions/node/v22.11.0/lib/node_modules/npm/node_modules/@npmcli/run-script/lib/run-script-pkg.js:77:13)
npm verbose stack     at runScript (/home/shun/.nvm/versions/node/v22.11.0/lib/node_modules/npm/node_modules/@npmcli/run-script/lib/run-script.js:9:12)
npm verbose stack     at /home/shun/.nvm/versions/node/v22.11.0/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js:329:17
npm verbose stack     at run (/home/shun/.nvm/versions/node/v22.11.0/lib/node_modules/npm/node_modules/promise-call-limit/dist/commonjs/index.js:67:22)
npm verbose stack     at /home/shun/.nvm/versions/node/v22.11.0/lib/node_modules/npm/node_modules/promise-call-limit/dist/commonjs/index.js:84:9
npm verbose stack     at new Promise (<anonymous>)
npm verbose stack     at callLimit (/home/shun/.nvm/versions/node/v22.11.0/lib/node_modules/npm/node_modules/promise-call-limit/dist/commonjs/index.js:35:69)
npm verbose pkgid electron@33.0.2
npm error code 1
npm error path /home/shun/Documents/Projects/netron/netron/node_modules/electron
npm error command failed
npm error command sh -c node install.js
npm error HTTPError: Response code 404 (Not Found)
npm error     at Request._onResponseBase (/home/shun/Documents/Projects/netron/netron/node_modules/got/dist/source/core/index.js:913:31)
npm error     at Request._onResponse (/home/shun/Documents/Projects/netron/netron/node_modules/got/dist/source/core/index.js:948:24)
npm error     at ClientRequest.<anonymous> (/home/shun/Documents/Projects/netron/netron/node_modules/got/dist/source/core/index.js:962:23)
npm error     at Object.onceWrapper (node:events:633:26)
npm error     at ClientRequest.emit (node:events:530:35)
npm error     at origin.emit (/home/shun/Documents/Projects/netron/netron/node_modules/@szmarczak/http-timer/dist/source/index.js:43:20)
npm error     at HTTPParser.parserOnIncomingClient (node:_http_client:704:27)
npm error     at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)
npm error     at TLSSocket.socketOnData (node:_http_client:546:22)
npm error     at TLSSocket.emit (node:events:518:28)
npm verbose cwd /home/shun/Documents/Projects/netron/netron
npm verbose os Linux 6.2.0-26-generic
npm verbose node v22.11.0
npm verbose npm  v10.9.0
npm verbose exit 1
npm verbose code 1
npm error A complete log of this run can be found in: /home/shun/.npm/_logs/2024-11-03T12_41_59_205Z-debug-0.log
Command failed: npm install
npm verbose cwd /home/shun/Documents/Projects/netron/netron
npm verbose os Linux 6.2.0-26-generic
npm verbose node v22.11.0
npm verbose npm  v10.9.0
npm verbose exit 1
npm verbose code 1

```

`electron@33.0.1` works ~ Can we change the version?