### PR TITLE
Reduce crossings of connection lines

### DIFF
--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1402,6 +1402,8 @@ dagre.layout = (nodes, edges, layout, state) => {
                             || n1.in.length !== 1
                             || n0.out.length !== 1
                             || n1.out.length !== 1
+                            || n0.in[0].vNode.in.length == 0
+                            || n1.in[0].vNode.in.length == 0
                         ) {
                             if (dirTotal === 3) {
                                 {

--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1402,8 +1402,8 @@ dagre.layout = (nodes, edges, layout, state) => {
                             || n1.in.length !== 1
                             || n0.out.length !== 1
                             || n1.out.length !== 1
-                            || n0.in[0].vNode.in.length == 0
-                            || n1.in[0].vNode.in.length == 0
+                            || n0.in[0].vNode.in.length === 0
+                            || n1.in[0].vNode.in.length === 0
                         ) {
                             if (dirTotal === 3) {
                                 {

--- a/source/dagre.js
+++ b/source/dagre.js
@@ -1369,7 +1369,7 @@ dagre.layout = (nodes, edges, layout, state) => {
         // https://stackoverflow.com/a/62854671
         function perm(array, length) {
             return array.flatMap((v, i) => length > 1
-                ? perm(array.slice(i + 1), length - 1).map(w => [v, ...w])
+                ? perm(array.slice(i + 1), length - 1).map((w) => [v, ...w])
                 : [[v]]
             );
         }

--- a/source/dot.js
+++ b/source/dot.js
@@ -169,7 +169,7 @@ dot.Graph = class {
         }
         for (const [key, node] of nodes) {
             const keys = new Set(['pos', 'height', 'width', 'shape', 'label']);
-            if (node.metadata.get('shape') === 'octagon' && node.metadata.keys().every((key) => keys.has(key)) &&
+            if (node.metadata.get('shape') === 'octagon' && Array.from(node.metadata.keys()).every((key) => keys.has(key)) &&
                 node.inputs.length === 1 && node.inputs[0].uses.length === 1 && node.inputs[0].from.outputs.length === 1 && node.inputs[0].from.outputs[0].uses.length === 1 &&
                 new Set(node.outputs.map((output) => output.name.id)).size === 1 && node.outputs.every((output) => output.uses.length === 1)) {
                 const [from] = node.inputs[0].from.outputs;


### PR DESCRIPTION
This PR is a sequel of #1330, #1327 and #1261.

The crossings around the green rectangles are cleared.

<details><summary>retinanet_resnet50_fpn_v2_Opset18.onnx</summary>

Left : Before
Right : Ater

![Untitled](https://github.com/user-attachments/assets/78bc51af-81d7-4a06-9de2-85f80721b8c6)

![image](https://github.com/user-attachments/assets/afe27031-6e30-4fd4-8b1b-1e42b6ec0394)

</details>

<details><summary>efficientdet-d3.onnx</summary>

Left : Before
Right : Ater

![Untitled](https://github.com/user-attachments/assets/cfc31fac-d488-42a9-aa7d-e0c54fd4479a)

</details>

<details><summary>saved_model.pbtxt</summary>

Left : Before
Right : Ater

![image](https://github.com/user-attachments/assets/3e31580a-8376-4fe8-8799-1858d8996ee9)

![image](https://github.com/user-attachments/assets/3b6ef55b-e59a-44fb-86c7-1241582d696a)

![image](https://github.com/user-attachments/assets/17954984-1ca1-4ac5-b96d-eb6b0927f772)

</details>
