### PR TITLE
show json in attributes

### DIFF
--- a/source/view.js
+++ b/source/view.js
@@ -700,11 +700,24 @@ view.View = class {
         return this._modelFactoryService.accept(file, size);
     }
 
-    async open(context) {
+    async open(context, ext_datas = null) {
         this._sidebar.close();
         await this._timeout(2);
         try {
             const model = await this._modelFactoryService.open(context);
+            if (ext_datas) {
+                for (const graph of model.graphs) {
+                    for (const node of graph.nodes) {
+                        const ext_data = ext_datas[node.name];
+                        if (ext_data) {
+                            for (const key in ext_data) {
+                                const attribute = {name: '- ' + key, value: ext_data[key], type: 'float64', description: null, visible: true};
+                                node.attributes.push(attribute);
+                            }
+                        }
+                    }
+                }
+            }
             const format = [];
             if (model.format) {
                 format.push(model.format);


### PR DESCRIPTION
I think this simple approach is enough to use?

- Add an open external data menu
- Add a new attribute in node like ext-data
- Add a Show / Hide External Data

So we could show external data in the node

The input json will be in the format
{
  "node name1": {  "ext1": 123, "ext2": 456 },
  ...
}