### PR TITLE
PyTorch Export: Fix TensorArgument in BufferMutationSpec

### DIFF
--- a/source/python.js
+++ b/source/python.js
@@ -17789,7 +17789,7 @@ python.Execution = class {
         });
         this.registerType('torch._export.serde.schema.BufferMutationSpec', class {
             constructor(obj) {
-                this.arg = new torch._export.serde.schema.Argument(obj.arg);
+                this.arg = new torch._export.serde.schema.TensorArgument(obj.arg);
                 this.buffer_name = obj.buffer_name;
             }
         });


### PR DESCRIPTION
We get `Unsupported argument: 'name'` error when opening torch.export exported models when model has buffer mutation n output. BufferMutationSpec in graph_signature output_spec should be read directly as TensorArgument.

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/0e843b6d-fad3-4771-870f-f825a9a0b0c1" />

example serialized graph module:
```json
"graph_module": {
    "graph": { ... },
    "signature": {
        "input_specs": [ ... ],
        "output_specs": [
            {
                "buffer_mutation": {
                    "arg": {
                        "name": "getitem_3"
                    },
                    "buffer_name": "bn1.running_mean"
                }
            },
        ]
    }
}
```

[serialized_exported_program.json](https://github.com/user-attachments/files/19599548/serialized_exported_program.json)

or you can export it by yourself by running the python script below:
```python
import torch
from torchvision.models import resnet18

model = resnet18()
exported_program = torch.export.export(model, (torch.randn(1, 3, 224, 224),))
torch.export.save(exported_program, "resnet.pt2")
```

