### PR TITLE
Windows path separator (\) fix

### DIFF
--- a/source/server.py
+++ b/source/server.py
@@ -96,7 +96,7 @@ class _HTTPRequestHandler(http.server.BaseHTTPRequestHandler):
                     base = self.content.base
                     if base:
                         meta.append('<meta name="file" content="/data/' + base + '">')
-                    name = self.content.name
+                    name = self.content.name.replace("\\", "\\\\")
                     if name:
                         meta.append('<meta name="name" content="' + name + '">')
                     identifier = self.content.identifier


### PR DESCRIPTION
If specifying (on *Win* ) a model path containing "***\\***", an error is present in the console:

```
(py_pc064_03.12_test0) [cfati@CFATI-5510-0:e:\Work\Dev\Projects\Everseen\TechAccelerators\Qualcomm\AIC100\models\chk_gen_int\24q4sco_v0]> python -m netron.__init__ --host 127.0.0.1 -p 6114 ..\22q1_v0\graphs\model.onnx
Serving '..\22q1_v0\graphs\model.onnx' at http://127.0.0.1:6114
----------------------------------------
Exception occurred during processing of request from ('127.0.0.1', 4220)
Traceback (most recent call last):
  File "c:\Install\pc064\Python\Python\03.12\Lib\socketserver.py", line 692, in process_request_thread
    self.finish_request(request, client_address)
  File "c:\Install\pc064\Python\Python\03.12\Lib\socketserver.py", line 362, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "c:\Install\pc064\Python\Python\03.12\Lib\socketserver.py", line 761, in __init__
    self.handle()
  File "c:\Install\pc064\Python\Python\03.12\Lib\http\server.py", line 436, in handle
    self.handle_one_request()
  File "c:\Install\pc064\Python\Python\03.12\Lib\http\server.py", line 424, in handle_one_request
    method()
  File "E:\Work\Dev\VEnvs\py_pc064_03.12_test0\Lib\site-packages\netron\server.py", line 110, in do_GET
    content = re.sub(regex, meta, content)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Install\pc064\Python\Python\03.12\Lib\re\__init__.py", line 186, in sub
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Install\pc064\Python\Python\03.12\Lib\re\__init__.py", line 334, in _compile_template
    return _sre.template(pattern, _parser.parse_template(repl, pattern))
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Install\pc064\Python\Python\03.12\Lib\re\_parser.py", line 1069, in parse_template
    addgroup(int(this[1:]), len(this) - 1)
  File "c:\Install\pc064\Python\Python\03.12\Lib\re\_parser.py", line 1014, in addgroup
    raise s.error("invalid group reference %d" % index, pos)
re.error: invalid group reference 22 at position 150 (line 4, column 31)
----------------------------------------
```

The exception keeps popping, the server is not able to process the request, and as a consequence ***This site can’t be reached*** or ***This page isn’t working*** is displayed in the browser.

The problem is that when performing `re.sub`, the (1<sup>st</sup>) *\\* from the path is interpreted in this case as a backreference which doesn't exist (but the error differs depending on what *char* comes after it).
The fix is to escape it.
