### PR TITLE
Find sidebar node type filter

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -247,9 +247,9 @@ button { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI"
 .sidebar-separator { margin-bottom: 20px; }
 .sidebar-find-search { display: flex; align-items: center; background: #fff; border-radius: 16px; margin: 0px 20px 8px 20px; padding: 0px 8px 0px 8px; }
 .sidebar-find-query { flex: 1; background: none; font-family: inherit; font-size: 13px; padding: 8px 8px 8px 8px; border: 0; outline: 0; }
-.sidebar-find-nodetype-filter { font-family: inherit; font-size: 11px; padding: 0 16px 0 0; margin-left: 6px; margin-right: 0; border: 0; background: transparent; outline: 0; cursor: pointer; color: #999; appearance: none; -webkit-appearance: none; -moz-appearance: none; background-image: linear-gradient(45deg, transparent 50%, #bbb 50%), linear-gradient(135deg, #bbb 50%, transparent 50%); background-position: calc(100% - 6px) calc(50%), calc(100% - 2px) calc(50%); background-size: 3px 3px, 3px 3px; background-repeat: no-repeat; min-width: 60px; }
-.sidebar-find-nodetype-filter:hover { color: #666; background-image: linear-gradient(45deg, transparent 50%, #888 50%), linear-gradient(135deg, #888 50%, transparent 50%); }
-.sidebar-find-nodetype-filter:focus { color: #666; outline: 0; }
+.sidebar-find-nodetype-dropdown { position: absolute; right: 0; top: 100%; margin-top: 4px; background: #fff; border: 1px solid #ddd; border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.15); z-index: 1000; min-width: 120px; max-height: 200px; overflow-y: auto; }
+.sidebar-find-nodetype-dropdown > div { padding: 6px 12px; cursor: pointer; font-size: 12px; color: #333; }
+.sidebar-find-nodetype-dropdown > div:hover { background: #f5f5f5; }
 .sidebar-find-toggle { margin-left: auto; margin-right: 2px; width: 16px; height: 16px; cursor: pointer; }
 .sidebar-find-toggle input[type="checkbox"] { display: none; }
 .sidebar-find-toggle input[type="checkbox"]:not(:checked) + svg { fill: #ccc; stroke: #ccc; }
@@ -293,9 +293,9 @@ button { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI"
     .sidebar-documentation code { background-color: #1e1e1e; }
     .sidebar-documentation pre { background-color: #1e1e1e; }
     .sidebar-find-search { background: #383838; color: #dfdfdf; border-color: #424242; }
-    .sidebar-find-nodetype-filter { background: transparent; color: #666; background-image: linear-gradient(45deg, transparent 50%, #777 50%), linear-gradient(135deg, #777 50%, transparent 50%); }
-    .sidebar-find-nodetype-filter:hover { color: #aaa; background-image: linear-gradient(45deg, transparent 50%, #999 50%), linear-gradient(135deg, #999 50%, transparent 50%); }
-    .sidebar-find-nodetype-filter:focus { color: #aaa; outline: 0; }
+    .sidebar-find-nodetype-dropdown { background: #383838; border-color: #555; }
+    .sidebar-find-nodetype-dropdown > div { color: #dfdfdf; }
+    .sidebar-find-nodetype-dropdown > div:hover { background: #424242; }
     .sidebar-find-toggle input[type="checkbox"]:not(:checked) + svg { fill: #555; stroke: #555; }
     .sidebar-find-toggle input[type="checkbox"]:checked + svg { fill: #aaa; stroke: #aaa; }
     .sidebar-find-content li { color: #aaaaaa; }
@@ -340,6 +340,11 @@ button { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI"
                 <circle cx="10" cy="15" r="1" />
                 <circle cx="15" cy="15" r="1" />
           </symbol>
+            <symbol id="sidebar-icon-filter" viewBox="0 0 20 20">
+                <line x1="4" y1="5" x2="16" y2="5" stroke-width="2" stroke-linecap="round"/>
+                <line x1="6" y1="10" x2="14" y2="10" stroke-width="2" stroke-linecap="round"/>
+                <line x1="8" y1="15" x2="12" y2="15" stroke-width="2" stroke-linecap="round"/>
+            </symbol>
         </defs>
     </svg>
 </div>

--- a/source/index.html
+++ b/source/index.html
@@ -246,7 +246,10 @@ button { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI"
 }
 .sidebar-separator { margin-bottom: 20px; }
 .sidebar-find-search { display: flex; align-items: center; background: #fff; border-radius: 16px; margin: 0px 20px 8px 20px; padding: 0px 8px 0px 8px; }
-.sidebar-find-query { width: 100vw; background: none; font-family: inherit; font-size: 13px; padding: 8px 8px 8px 8px; border: 0; outline: 0; }
+.sidebar-find-query { flex: 1; background: none; font-family: inherit; font-size: 13px; padding: 8px 8px 8px 8px; border: 0; outline: 0; }
+.sidebar-find-nodetype-filter { font-family: inherit; font-size: 11px; padding: 0 16px 0 0; margin-left: 6px; margin-right: 0; border: 0; background: transparent; outline: 0; cursor: pointer; color: #999; appearance: none; -webkit-appearance: none; -moz-appearance: none; background-image: linear-gradient(45deg, transparent 50%, #bbb 50%), linear-gradient(135deg, #bbb 50%, transparent 50%); background-position: calc(100% - 6px) calc(50%), calc(100% - 2px) calc(50%); background-size: 3px 3px, 3px 3px; background-repeat: no-repeat; min-width: 60px; }
+.sidebar-find-nodetype-filter:hover { color: #666; background-image: linear-gradient(45deg, transparent 50%, #888 50%), linear-gradient(135deg, #888 50%, transparent 50%); }
+.sidebar-find-nodetype-filter:focus { color: #666; outline: 0; }
 .sidebar-find-toggle { margin-left: auto; margin-right: 2px; width: 16px; height: 16px; cursor: pointer; }
 .sidebar-find-toggle input[type="checkbox"] { display: none; }
 .sidebar-find-toggle input[type="checkbox"]:not(:checked) + svg { fill: #ccc; stroke: #ccc; }
@@ -290,6 +293,9 @@ button { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI"
     .sidebar-documentation code { background-color: #1e1e1e; }
     .sidebar-documentation pre { background-color: #1e1e1e; }
     .sidebar-find-search { background: #383838; color: #dfdfdf; border-color: #424242; }
+    .sidebar-find-nodetype-filter { background: transparent; color: #666; background-image: linear-gradient(45deg, transparent 50%, #777 50%), linear-gradient(135deg, #777 50%, transparent 50%); }
+    .sidebar-find-nodetype-filter:hover { color: #aaa; background-image: linear-gradient(45deg, transparent 50%, #999 50%), linear-gradient(135deg, #999 50%, transparent 50%); }
+    .sidebar-find-nodetype-filter:focus { color: #aaa; outline: 0; }
     .sidebar-find-toggle input[type="checkbox"]:not(:checked) + svg { fill: #555; stroke: #555; }
     .sidebar-find-toggle input[type="checkbox"]:checked + svg { fill: #aaa; stroke: #aaa; }
     .sidebar-find-content li { color: #aaaaaa; }

--- a/source/view.js
+++ b/source/view.js
@@ -4318,20 +4318,20 @@ view.FindSidebar = class extends view.Control {
         this._search = this.createElement('div', 'sidebar-find-search');
         this._query = this.createElement('input', 'sidebar-find-query');
         this._search.appendChild(this._query);
-        
+
         // Add node type filter button for ONNX models
         if (this._isOnnxModel) {
             const container = this.createElement('div');
             container.style.position = 'relative';
-            
+
             this._nodeTypeFilterButton = this.createElement('label', 'sidebar-find-toggle');
             this._nodeTypeFilterButton.innerHTML = `<svg class='sidebar-find-toggle-icon'><use href="#sidebar-icon-filter"></use></svg>`;
             this._nodeTypeFilterButton.setAttribute('title', 'Filter by Node Type');
-            
+
             // Create dropdown menu (initially hidden)
             this._nodeTypeDropdown = this.createElement('div', 'sidebar-find-nodetype-dropdown');
             this._nodeTypeDropdown.style.display = 'none';
-            
+
             const defaultOption = this.createElement('div');
             defaultOption.style.padding = '6px 12px';
             defaultOption.style.cursor = 'pointer';
@@ -4345,7 +4345,7 @@ view.FindSidebar = class extends view.Control {
                 this._nodeTypeDropdown.style.display = 'none';
             });
             this._nodeTypeDropdown.appendChild(defaultOption);
-            
+
             const nodeTypes = this._collectNodeTypes();
             for (const nodeType of nodeTypes) {
                 const option = this.createElement('div');
@@ -4372,16 +4372,16 @@ view.FindSidebar = class extends view.Control {
                 });
                 this._nodeTypeDropdown.appendChild(option);
             }
-            
+
             container.appendChild(this._nodeTypeFilterButton);
             container.appendChild(this._nodeTypeDropdown);
-            
+
             this._nodeTypeFilterButton.addEventListener('click', (e) => {
                 e.stopPropagation();
                 const isVisible = this._nodeTypeDropdown.style.display !== 'none';
                 this._nodeTypeDropdown.style.display = isVisible ? 'none' : 'block';
             });
-            
+
             // Close dropdown when clicking outside
             const closeDropdown = (e) => {
                 if (container && !container.contains(e.target)) {
@@ -4389,13 +4389,13 @@ view.FindSidebar = class extends view.Control {
                 }
             };
             this._host.document.addEventListener('click', closeDropdown);
-            
+
             const nodeTypesList = nodeTypes;
             this._updateDropdownSelection = () => {
                 const options = this._nodeTypeDropdown.children;
                 for (let i = 0; i < options.length; i++) {
                     const option = options[i];
-                    const isSelected = (i === 0 && this._state.nodeType === '') || 
+                    const isSelected = (i === 0 && this._state.nodeType === '') ||
                                       (i > 0 && this._state.nodeType === nodeTypesList[i - 1]);
                     option.style.color = isSelected ? '#2e6bd2' : '';
                     option.style.fontWeight = isSelected ? 'bold' : 'normal';
@@ -4404,11 +4404,11 @@ view.FindSidebar = class extends view.Control {
                     }
                 }
             };
-            
+
             this._search.appendChild(container);
             this._updateDropdownSelection();
         }
-        
+
         this._content = this.createElement('ol', 'sidebar-find-content');
         this._elements = [this._query, this._content];
         this._query.setAttribute('id', 'search');

--- a/source/view.js
+++ b/source/view.js
@@ -4072,13 +4072,15 @@ view.FindSidebar = class extends view.Control {
             query: '',
             node: true,
             connection: true,
-            weight: true
+            weight: true,
+            nodeType: ''
         };
         this._toggles = {
             node: { hide: 'Hide Nodes', show: 'Show Nodes' },
             connection: { hide: 'Hide Connections', show: 'Show Connections' },
             weight: { hide: 'Hide Weights', show: 'Show Weights' }
         };
+        this._isOnnxModel = this._view._model && this._view._model.format && this._view._model.format.startsWith('ONNX');
     }
 
     get identifier() {
@@ -4194,6 +4196,13 @@ view.FindSidebar = class extends view.Control {
             const name = node.name;
             const type = node.type.name;
             const identifier = node.identifier;
+            // Apply node type filter for ONNX models
+            if (this._isOnnxModel && this._state.nodeType && this._state.nodeType !== '') {
+                const nodeTypeName = type.split('.').pop(); // Get base type name (e.g., "Conv" from "ai.onnx.Conv")
+                if (nodeTypeName.toLowerCase() !== this._state.nodeType.toLowerCase()) {
+                    return; // Skip nodes that don't match the selected type
+                }
+            }
             if ((name && this._term(name)) || (type && this._term(type)) || (identifier && this._term(identifier))) {
                 const content = `${name || `[${type}]`}`;
                 this._add(node, content, 'node');
@@ -4259,6 +4268,20 @@ view.FindSidebar = class extends view.Control {
         }
     }
 
+    _collectNodeTypes() {
+        if (!this._isOnnxModel || !this._target || !this._target.nodes) {
+            return [];
+        }
+        const nodeTypes = new Set();
+        for (const node of this._target.nodes) {
+            if (node.type && node.type.name) {
+                const typeName = node.type.name.split('.').pop(); // Get base type name (e.g., "Conv" from "ai.onnx.Conv")
+                nodeTypes.add(typeName);
+            }
+        }
+        return Array.from(nodeTypes).sort();
+    }
+
     _update() {
         try {
             this._reset();
@@ -4295,6 +4318,33 @@ view.FindSidebar = class extends view.Control {
         this._search = this.createElement('div', 'sidebar-find-search');
         this._query = this.createElement('input', 'sidebar-find-query');
         this._search.appendChild(this._query);
+        
+        // Add node type filter dropdown for ONNX models
+        if (this._isOnnxModel) {
+            this._nodeTypeSelect = this.createElement('select', 'sidebar-find-nodetype-filter');
+            this._nodeTypeSelect.setAttribute('title', 'Filter by Node Type');
+            const defaultOption = this.createElement('option');
+            defaultOption.value = '';
+            defaultOption.textContent = 'All Types';
+            this._nodeTypeSelect.appendChild(defaultOption);
+            
+            const nodeTypes = this._collectNodeTypes();
+            for (const nodeType of nodeTypes) {
+                const option = this.createElement('option');
+                option.value = nodeType;
+                option.textContent = nodeType;
+                this._nodeTypeSelect.appendChild(option);
+            }
+            
+            this._nodeTypeSelect.value = this._state.nodeType || '';
+            this._nodeTypeSelect.addEventListener('change', (e) => {
+                this._state.nodeType = e.target.value;
+                this.emit('state-changed', this._state);
+                this._update();
+            });
+            this._search.appendChild(this._nodeTypeSelect);
+        }
+        
         this._content = this.createElement('ol', 'sidebar-find-content');
         this._elements = [this._query, this._content];
         this._query.setAttribute('id', 'search');
@@ -4358,6 +4408,9 @@ view.FindSidebar = class extends view.Control {
         for (const [name, toggle] of Object.entries(this._toggles)) {
             toggle.checkbox.checked = this._state[name];
             toggle.element.setAttribute('title', this._state[name] ? toggle.hide : toggle.show);
+        }
+        if (this._isOnnxModel && this._nodeTypeSelect) {
+            this._nodeTypeSelect.value = this._state.nodeType || '';
         }
         this._update();
         this._host.event('open_sidebar', {


### PR DESCRIPTION
# Problem

When working with large ONNX models, the search sidebar can list thousands of nodes. Filtering by name works, but it's hard to focus on specific operation types (e.g., finding all Conv, MatMul, or GroupQueryAttention nodes). Users had to scroll through many results or type exact names, which is slow for exploratory work.

## Solution
<img width="675" height="443" alt="image" src="https://github.com/user-attachments/assets/21cde099-d495-4edc-863c-21d11d62443c" />

Add a node type filter in the search sidebar for ONNX models. A filter icon button appears next to the search input, matching the existing toggle button style. Clicking it opens a dropdown with all unique node types found in the model. Selecting a type filters the results to show only nodes of that type, and it works together with text search for more precise filtering.

## Implementation Details

### Key Features:

- **Filter icon button**: A filter icon (three horizontal lines) appears in the search bar for ONNX models, styled like the existing toggle buttons

- **Dynamic node type collection**: Automatically collects and lists all unique node types from the model (e.g., Conv, MatMul, Add, GroupQueryAttention, Cast, Concat, etc.)

- **Dropdown menu**: Clicking the filter icon opens a dropdown with:
  - "All Types" option to clear the filter
  - Sorted list of all unique node types
  - Visual indication of the selected type (blue color, bold text)
  - Hover effects for better UX

- **Combined filtering**: Works with the existing text search — users can filter by type and search by name simultaneously

- **ONNX-only**: Only appears when viewing ONNX models (detected by checking if model format starts with "ONNX")

- **State persistence**: Selected filter state is preserved when the sidebar is reopened

### Technical Changes:

- Added `nodeType` to the search state object
- Implemented `_collectNodeTypes()` method to extract unique node types from the model graph
- Modified `_node()` filtering logic to respect the node type filter
- Added filter icon SVG symbol (`sidebar-icon-filter`) to match existing icon style
- Implemented dropdown menu with proper event handling and click-outside-to-close behavior
- Added CSS styling with dark mode support

@lutzroeder , long time user, first PR,  please help review. 
