### PR TITLE
[OpenVINO] Fix dynamic type handling for non-folded constants

### DIFF
--- a/source/openvino.js
+++ b/source/openvino.js
@@ -650,6 +650,7 @@ openvino.Node = class {
                 case 'I64':  case 'U64': case 'FP64': itemSize = 8; break;
                 case 'F8E4M3':                        itemSize = 1; break;
                 case 'BF16':                          itemSize = 2; break;
+                case 'DYNAMIC':                       itemSize = 0; break;
                 default: throw new openvino.Error(`Unsupported data type size '${precision}'.`);
             }
             const weight = (name, precision, dimensions, data) => {

--- a/test/models.json
+++ b/test/models.json
@@ -5165,6 +5165,13 @@
   },
   {
     "type":     "openvino",
+    "target":   "dynamic-no-fold.xml",
+    "source":   "TODO_UPLOAD_AND_REPLACE[dynamic-no-fold.xml]",
+    "format":   "OpenVINO IR",
+    "link":     "https://github.com/lutzroeder/netron/issues/191"
+  },
+  {
+    "type":     "openvino",
     "target":   "face-detection-retail-0005.bin,face-detection-retail-0005.xml",
     "source":   "https://github.com/lutzroeder/netron/files/12750770/face-detection-retail-0005.zip[face-detection-retail-0005.bin,face-detection-retail-0005.xml]",
     "format":   "OpenVINO IR",


### PR DESCRIPTION
When Constant input is not folded a different code path is taken.
Extra test has been added.
[dynamic-no-fold.xml.gz](https://github.com/user-attachments/files/25238742/dynamic-no-fold.xml.gz)
