### PR TITLE
onednn: add s64 data type

### DIFF
--- a/source/onednn.js
+++ b/source/onednn.js
@@ -229,6 +229,7 @@ onednn.TensorType = class {
             case 's4': this.dataType = 'int4'; break;
             case 's8': this.dataType = 'int8'; break;
             case 's32': this.dataType = 'int32'; break;
+            case 's64': this.dataType = 'int64'; break;
             case 'u4': this.dataType = 'uint4'; break;
             case 'u8': this.dataType = 'uint8'; break;
             case 'bf16': this.dataType = 'bfloat16'; break;


### PR DESCRIPTION
Add s64 (int64) data type to onednn.js. It's definition in oneDNN is at [here](https://github.com/uxlfoundation/oneDNN/blob/main/include/oneapi/dnnl/dnnl_graph.hpp#L281).