### PR TITLE
Return to welcome screen after error handling

### DIFF
--- a/source/browser.js
+++ b/source/browser.js
@@ -469,6 +469,7 @@ browser.Host = class {
             await this._openContext(context);
         } catch (error) {
             await this._view.error(error);
+            this._view.show('welcome');
         }
     }
 
@@ -522,6 +523,7 @@ browser.Host = class {
             return 'context-open-failed';
         } catch (error) {
             await this._view.error(error, error.name);
+            this._view.show('welcome');
             return 'context-open-error';
         }
     }

--- a/source/view.js
+++ b/source/view.js
@@ -717,7 +717,7 @@ view.View = class {
         if (report) {
             this._host.openURL(url);
         }
-        this.show(screen === undefined || screen === null ? 'welcome' : screen);
+        this.show(screen);
     }
 
     accept(file, size) {

--- a/source/view.js
+++ b/source/view.js
@@ -717,7 +717,7 @@ view.View = class {
         if (report) {
             this._host.openURL(url);
         }
-        this.show(screen);
+        this.show(screen === undefined || screen === null ? 'welcome' : screen);
     }
 
     accept(file, size) {

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -68,12 +68,14 @@ playwright.test('browser', async ({ page }) => {
     playwright.expect(first).toBe(0.1353299617767334);
 });
 
-playwright.test('error handling - corrupted file shows error and returns to welcome', async ({ page }) => {
+playwright.test('error handling - corrupted file shows error and can reopen normal file', async ({ page }) => {
     const self = url.fileURLToPath(import.meta.url);
     const dir = path.dirname(self);
     const corruptedFile = path.resolve(dir, 'corrupted.onnx');
+    const normalFile = path.resolve(dir, '../third_party/test/onnx/candy.onnx');
 
     playwright.expect(fs.existsSync(corruptedFile)).toBeTruthy();
+    playwright.expect(fs.existsSync(normalFile)).toBeTruthy();
 
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
@@ -88,10 +90,10 @@ playwright.test('error handling - corrupted file shows error and returns to welc
     const openButton = await page.locator('.open-file-button, button:has-text("Open Model")');
     playwright.expect(await openButton.isVisible()).toBeTruthy();
 
-    const fileChooserPromise = page.waitForEvent('filechooser');
+    const fileChooserPromise1 = page.waitForEvent('filechooser');
     await openButton.click();
-    const fileChooser = await fileChooserPromise;
-    await fileChooser.setFiles(corruptedFile);
+    const fileChooser1 = await fileChooserPromise1;
+    await fileChooser1.setFiles(corruptedFile);
 
     await page.waitForSelector('body.welcome.spinner', { timeout: 5000 });
 
@@ -108,13 +110,26 @@ playwright.test('error handling - corrupted file shows error and returns to welc
 
     await page.waitForSelector('body.welcome', { timeout: 5000 });
 
-    const bodyClass = await page.getAttribute('body', 'class');
-    playwright.expect(bodyClass).toContain('welcome');
-    playwright.expect(bodyClass).not.toContain('spinner');
-    playwright.expect(bodyClass).not.toContain('notification');
-    playwright.expect(bodyClass).not.toContain('alert');
+    const bodyClassAfterError = await page.getAttribute('body', 'class');
+    playwright.expect(bodyClassAfterError).toContain('welcome');
+    playwright.expect(bodyClassAfterError).not.toContain('spinner');
+    playwright.expect(bodyClassAfterError).not.toContain('notification');
+    playwright.expect(bodyClassAfterError).not.toContain('alert');
 
     const openButtonAfterError = await page.locator('.open-file-button, button:has-text("Open Model")');
     playwright.expect(await openButtonAfterError.isVisible()).toBeTruthy();
     playwright.expect(await openButtonAfterError.isEnabled()).toBeTruthy();
+
+    const fileChooserPromise2 = page.waitForEvent('filechooser');
+    await openButtonAfterError.click();
+    const fileChooser2 = await fileChooserPromise2;
+    await fileChooser2.setFiles(normalFile);
+
+    await page.waitForSelector('#canvas', { state: 'attached', timeout: 10000 });
+    await page.waitForSelector('body.default', { timeout: 10000 });
+
+    const bodyClassAfterSuccess = await page.getAttribute('body', 'class');
+    playwright.expect(bodyClassAfterSuccess).toContain('default');
+    playwright.expect(bodyClassAfterSuccess).not.toContain('welcome');
+    playwright.expect(bodyClassAfterSuccess).not.toContain('spinner');
 });

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -67,3 +67,54 @@ playwright.test('browser', async ({ page }) => {
     const first = parseFloat(match[0]);
     playwright.expect(first).toBe(0.1353299617767334);
 });
+
+playwright.test('error handling - corrupted file shows error and returns to welcome', async ({ page }) => {
+    const self = url.fileURLToPath(import.meta.url);
+    const dir = path.dirname(self);
+    const corruptedFile = path.resolve(dir, 'corrupted.onnx');
+
+    playwright.expect(fs.existsSync(corruptedFile)).toBeTruthy();
+
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForSelector('body.welcome', { timeout: 25000 });
+    await page.waitForTimeout(1000);
+
+    const consent = await page.locator('#message-button');
+    if (await consent.isVisible({ timeout: 25000 })) {
+        await consent.click();
+    }
+
+    const openButton = await page.locator('.open-file-button, button:has-text("Open Model")');
+    playwright.expect(await openButton.isVisible()).toBeTruthy();
+
+    const fileChooserPromise = page.waitForEvent('filechooser');
+    await openButton.click();
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(corruptedFile);
+
+    await page.waitForSelector('body.welcome.spinner', { timeout: 5000 });
+
+    await page.waitForSelector('body.notification, body.alert', { timeout: 15000 });
+
+    const messageText = await page.locator('#message-text');
+    const errorContent = await messageText.textContent();
+    playwright.expect(errorContent).not.toBe('');
+    playwright.expect(errorContent.length).toBeGreaterThan(0);
+
+    const messageButton = await page.locator('#message-button');
+    playwright.expect(await messageButton.isVisible()).toBeTruthy();
+    await messageButton.click();
+
+    await page.waitForSelector('body.welcome', { timeout: 5000 });
+
+    const bodyClass = await page.getAttribute('body', 'class');
+    playwright.expect(bodyClass).toContain('welcome');
+    playwright.expect(bodyClass).not.toContain('spinner');
+    playwright.expect(bodyClass).not.toContain('notification');
+    playwright.expect(bodyClass).not.toContain('alert');
+
+    const openButtonAfterError = await page.locator('.open-file-button, button:has-text("Open Model")');
+    playwright.expect(await openButtonAfterError.isVisible()).toBeTruthy();
+    playwright.expect(await openButtonAfterError.isEnabled()).toBeTruthy();
+});

--- a/test/corrupted.onnx
+++ b/test/corrupted.onnx
@@ -1,0 +1,1 @@
+This is not a valid ONNX file. It contains invalid data that should cause an error when opened in Netron.


### PR DESCRIPTION
fix: 修复错误处理后返回欢迎页面的问题

在浏览器错误处理中增加返回欢迎页面的逻辑，并更新测试用例验证错误处理后可以重新打开正常文件