### PR TITLE
TensorFlow Lite: Validate string tensor offsets

### DIFF
--- a/source/tflite.js
+++ b/source/tflite.js
@@ -468,18 +468,29 @@ tflite.Tensor = class {
             case 'string': {
                 let offset = 0;
                 const data = new DataView(this._data.buffer, this._data.byteOffset, this._data.byteLength);
+                if (data.byteLength < 4) {
+                    throw new tflite.Error(`Invalid string tensor '${this.name}'.`);
+                }
                 const count = data.getInt32(0, true);
+                if (count < 0 || count > Math.floor((data.byteLength - 4) / 4)) {
+                    throw new tflite.Error(`Invalid string tensor '${this.name}'.`);
+                }
                 offset += 4;
                 const offsetTable = [];
                 for (let j = 0; j < count; j++) {
-                    offsetTable.push(data.getInt32(offset, true));
+                    offsetTable.push(data.getUint32(offset, true));
                     offset += 4;
                 }
                 offsetTable.push(this._data.length);
                 const stringTable = [];
                 const utf8Decoder = new TextDecoder('utf-8');
                 for (let k = 0; k < count; k++) {
-                    const textArray = this._data.subarray(offsetTable[k], offsetTable[k + 1]);
+                    const start = offsetTable[k];
+                    const end = offsetTable[k + 1];
+                    if (start < offset || start > end || end > this._data.length) {
+                        throw new tflite.Error(`Invalid string tensor '${this.name}'.`);
+                    }
+                    const textArray = this._data.subarray(start, end);
                     stringTable.push(utf8Decoder.decode(textArray));
                 }
                 return stringTable;


### PR DESCRIPTION
This adds bounds validation for TFLite string tensor tables before decoding string values.

TFLite string tensors store a count followed by string offsets and payload bytes. The previous decoder trusted the count and offsets directly, so malformed tensor data could use an incomplete or overlapping offset table and still be decoded through Uint8Array.subarray() clamping semantics.

This change rejects malformed string tensor data when:
- the count header is missing,
- the count cannot fit in the available offset table,
- an offset points back into the table,
- offsets are out of order, or
- an offset points past the tensor data.

Validation:
- node --check source/tflite.js
- git diff --check
- Manual Node reproduction: a valid one-string TFLite string table decodes to ok, while an overlapping offset table now rejects instead of decoding bytes from the offset table.