### PR TITLE
Update VKNN .vxm reader for current containers (VXM3-VXM6)

### DIFF
--- a/source/base.js
+++ b/source/base.js
@@ -680,6 +680,13 @@ base.StreamReader = class {
     boolean() {
         return this.byte() === 0 ? false : true;
     }
+
+    string() {
+        const length = this.uint32();
+        const data = this._stream.read(length);
+        this._decoder = this._decoder || new TextDecoder('utf-8');
+        return this._decoder.decode(data);
+    }
 };
 
 base.Tensor = class {

--- a/source/view.js
+++ b/source/view.js
@@ -7275,7 +7275,7 @@ view.ModelFactoryService = class {
         this.register('./mslite', ['.ms', '.bin'], [], [/^....MSL0/, /^....MSL1/, /^....MSL2/]);
         this.register('./mindir', ['.mindir']);
         this.register('./barracuda', ['.nn']);
-        this.register('./vknn', ['.vxm'], [], [/^VXM1/]);
+        this.register('./vknn', ['.vxm'], [], [/^VXM[0-9]/]);
         this.register('./circle', ['.circle'], [], [/^....CIR0/]);
         this.register('./dnn', ['.dnn']);
         this.register('./xmodel', ['.xmodel']);

--- a/source/vknn-metadata.json
+++ b/source/vknn-metadata.json
@@ -1,46 +1,785 @@
 [
-  { "name": "Conv", "module": "vxm", "category": "Layer", "description": "2D convolution (includes depthwise via group and pointwise 1x1).", "inputs": [{ "name": "input" }, { "name": "weight" }, { "name": "bias" }] },
-  { "name": "Clip", "module": "vxm", "category": "Activation", "description": "Clamp values into the [min, max] range (Relu6 is Clip(0, 6)).", "inputs": [{ "name": "input" }] },
-  { "name": "Relu", "module": "vxm", "category": "Activation", "description": "Rectified linear unit, max(0, x).", "inputs": [{ "name": "input" }] },
-  { "name": "Add", "module": "vxm", "category": "Tensor", "description": "Element-wise addition (residual).", "inputs": [{ "name": "A" }, { "name": "B" }] },
-  { "name": "GlobalAvgPool", "module": "vxm", "category": "Pool", "description": "Global average pooling over the spatial dimensions.", "inputs": [{ "name": "input" }] },
-  { "name": "AvgPool", "module": "vxm", "category": "Pool", "description": "Average pooling.", "inputs": [{ "name": "input" }] },
-  { "name": "MaxPool", "module": "vxm", "category": "Pool", "description": "Max pooling.", "inputs": [{ "name": "input" }] },
-  { "name": "Gemm", "module": "vxm", "category": "Layer", "description": "General matrix multiply, Y = alpha*A*B + beta*C.", "inputs": [{ "name": "A" }, { "name": "B" }, { "name": "C" }] },
-  { "name": "MatMul", "module": "vxm", "category": "Layer", "description": "Matrix multiplication.", "inputs": [{ "name": "A" }, { "name": "B" }] },
-  { "name": "Einsum", "module": "vxm", "description": "Einstein summation (outer-product and batched mat-vec/matmul)." },
-  { "name": "Reshape", "module": "vxm", "category": "Shape", "description": "Reshape a tensor.", "inputs": [{ "name": "data" }, { "name": "shape" }] },
-  { "name": "Expand", "module": "vxm", "category": "Shape", "description": "Broadcast a tensor to a target shape.", "inputs": [{ "name": "input" }, { "name": "shape" }] },
-  { "name": "Tile", "module": "vxm", "category": "Shape", "description": "Repeat a tensor along each dimension.", "inputs": [{ "name": "input" }, { "name": "repeats" }] },
-  { "name": "Squeeze", "module": "vxm", "category": "Transform", "description": "Remove size-1 dimensions.", "inputs": [{ "name": "input" }] },
-  { "name": "Flatten", "module": "vxm", "category": "Shape", "description": "Flatten dimensions into a 2D matrix.", "inputs": [{ "name": "input" }] },
-  { "name": "Softmax", "module": "vxm", "category": "Activation", "description": "Softmax normalization.", "inputs": [{ "name": "input" }] },
-  { "name": "LayerNorm", "module": "vxm", "category": "Normalization", "description": "Layer normalization.", "inputs": [{ "name": "input" }, { "name": "scale" }, { "name": "bias" }] },
-  { "name": "BatchNorm", "module": "vxm", "category": "Normalization", "description": "Batch normalization.", "inputs": [{ "name": "input" }, { "name": "scale" }, { "name": "bias" }, { "name": "mean" }, { "name": "var" }] },
-  { "name": "Concat", "module": "vxm", "category": "Tensor", "description": "Concatenate tensors along an axis." },
-  { "name": "Pad", "module": "vxm", "category": "Shape", "description": "Pad a tensor.", "inputs": [{ "name": "input" }] },
-  { "name": "Identity", "module": "vxm", "description": "Identity (pass-through).", "inputs": [{ "name": "input" }] },
-  { "name": "Constant", "module": "vxm", "category": "Constant", "description": "A constant tensor." },
-  { "name": "Shape", "module": "vxm", "category": "Shape", "description": "Return the shape of a tensor.", "inputs": [{ "name": "input" }] },
-  { "name": "Gather", "module": "vxm", "category": "Transform", "description": "Gather slices along an axis.", "inputs": [{ "name": "data" }, { "name": "indices" }] },
-  { "name": "Unsqueeze", "module": "vxm", "category": "Transform", "description": "Insert size-1 dimensions.", "inputs": [{ "name": "input" }] },
-  { "name": "Unary", "module": "vxm", "description": "Element-wise unary op (see the operation attribute).", "inputs": [{ "name": "input" }] },
-  { "name": "Binary", "module": "vxm", "description": "Element-wise binary op (see the operation attribute).", "inputs": [{ "name": "A" }, { "name": "B" }] },
-  { "name": "PRelu", "module": "vxm", "category": "Activation", "description": "Parametric ReLU, per-channel slope.", "inputs": [{ "name": "input" }, { "name": "slope" }] },
-  { "name": "Resize", "module": "vxm", "category": "Data", "description": "Resize / upsample (nearest or linear).", "inputs": [{ "name": "input" }] },
-  { "name": "GridSample", "module": "vxm", "description": "Sample input at grid coordinates.", "inputs": [{ "name": "input" }, { "name": "grid" }] },
-  { "name": "Transpose", "module": "vxm", "category": "Transform", "description": "Permute dimensions.", "inputs": [{ "name": "input" }] },
-  { "name": "Slice", "module": "vxm", "category": "Tensor", "description": "Strided slice.", "inputs": [{ "name": "input" }] },
-  { "name": "Reduce", "module": "vxm", "description": "Reduction (mean/sum/max/min/prod/L2; see the operation attribute).", "inputs": [{ "name": "input" }] },
-  { "name": "DepthToSpace", "module": "vxm", "category": "Shape", "description": "Rearrange depth into spatial blocks.", "inputs": [{ "name": "input" }] },
-  { "name": "Cast", "module": "vxm", "description": "Cast to a different data type.", "inputs": [{ "name": "input" }] },
-  { "name": "Split", "module": "vxm", "category": "Tensor", "description": "Split a tensor along an axis.", "inputs": [{ "name": "input" }] },
-  { "name": "Where", "module": "vxm", "description": "Element-wise select, cond ? X : Y.", "inputs": [{ "name": "condition" }, { "name": "X" }, { "name": "Y" }] },
-  { "name": "Equal", "module": "vxm", "description": "Element-wise equality.", "inputs": [{ "name": "A" }, { "name": "B" }] },
-  { "name": "ConstantOfShape", "module": "vxm", "category": "Constant", "description": "Emit a tensor of a given shape filled with a scalar.", "inputs": [{ "name": "shape" }] },
-  { "name": "EyeLike", "module": "vxm", "category": "Constant", "description": "Identity-like matrix matching the input shape.", "inputs": [{ "name": "input" }] },
-  { "name": "ScatterND", "module": "vxm", "description": "Scatter update slices at N-D index rows.", "inputs": [{ "name": "data" }, { "name": "indices" }, { "name": "updates" }] },
-  { "name": "FusedSE", "module": "vxm", "category": "Normalization", "description": "Fused Squeeze-Excite scale (GAP -> FC -> relu -> FC -> hardsigmoid).", "inputs": [{ "name": "input" }] },
-  { "name": "FusedDwPw", "module": "vxm", "category": "Layer", "description": "Fused depthwise-3x3 + 1x1-project convolution.", "inputs": [{ "name": "input" }] },
-  { "name": "ConvertLayout", "module": "vxm", "category": "Shape", "description": "Tensor layout conversion (inserted by the layout pass).", "inputs": [{ "name": "input" }] }
+  {
+    "name": "Conv",
+    "module": "vxm",
+    "category": "Layer",
+    "description": "2D convolution (includes depthwise via group and pointwise 1x1).",
+    "inputs": [
+      { "name": "input" },
+      { "name": "weight" },
+      { "name": "bias" }
+    ]
+  },
+  {
+    "name": "ConvTranspose",
+    "module": "vxm",
+    "category": "Layer",
+    "description": "Transposed (fractionally-strided) convolution used for upsampling.",
+    "inputs": [
+      { "name": "input" },
+      { "name": "weight" },
+      { "name": "bias" }
+    ]
+  },
+  {
+    "name": "Clip",
+    "module": "vxm",
+    "category": "Activation",
+    "description": "Clamp values into the [min, max] range (Relu6 is Clip(0, 6)).",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Relu",
+    "module": "vxm",
+    "category": "Activation",
+    "description": "Rectified linear unit, max(0, x).",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Add",
+    "module": "vxm",
+    "category": "Tensor",
+    "description": "Element-wise addition (residual).",
+    "inputs": [
+      { "name": "A" },
+      { "name": "B" }
+    ]
+  },
+  {
+    "name": "GlobalAveragePool",
+    "module": "vxm",
+    "category": "Pool",
+    "description": "Global average pooling over the spatial dimensions.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "AveragePool",
+    "module": "vxm",
+    "category": "Pool",
+    "description": "Average pooling.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "MaxPool",
+    "module": "vxm",
+    "category": "Pool",
+    "description": "Max pooling.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Gemm",
+    "module": "vxm",
+    "category": "Layer",
+    "description": "General matrix multiply, Y = alpha*A*B + beta*C.",
+    "inputs": [
+      { "name": "A" },
+      { "name": "B" },
+      { "name": "C" }
+    ]
+  },
+  {
+    "name": "MatMul",
+    "module": "vxm",
+    "category": "Layer",
+    "description": "Matrix multiplication.",
+    "inputs": [
+      { "name": "A" },
+      { "name": "B" }
+    ]
+  },
+  {
+    "name": "Einsum",
+    "module": "vxm",
+    "description": "Einstein summation (outer-product and batched mat-vec/matmul)."
+  },
+  {
+    "name": "Reshape",
+    "module": "vxm",
+    "category": "Shape",
+    "description": "Reshape a tensor.",
+    "inputs": [
+      { "name": "data" },
+      { "name": "shape" }
+    ]
+  },
+  {
+    "name": "Expand",
+    "module": "vxm",
+    "category": "Shape",
+    "description": "Broadcast a tensor to a target shape.",
+    "inputs": [
+      { "name": "input" },
+      { "name": "shape" }
+    ]
+  },
+  {
+    "name": "Tile",
+    "module": "vxm",
+    "category": "Shape",
+    "description": "Repeat a tensor along each dimension.",
+    "inputs": [
+      { "name": "input" },
+      { "name": "repeats" }
+    ]
+  },
+  {
+    "name": "Squeeze",
+    "module": "vxm",
+    "category": "Transform",
+    "description": "Remove size-1 dimensions.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Flatten",
+    "module": "vxm",
+    "category": "Shape",
+    "description": "Flatten dimensions into a 2D matrix.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Softmax",
+    "module": "vxm",
+    "category": "Activation",
+    "description": "Softmax normalization.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "LayerNormalization",
+    "module": "vxm",
+    "category": "Normalization",
+    "description": "Layer normalization, y = (x - mean) / sqrt(var + eps) * scale + bias.",
+    "inputs": [
+      { "name": "input" },
+      { "name": "scale" },
+      { "name": "bias" }
+    ]
+  },
+  {
+    "name": "BatchNormalization",
+    "module": "vxm",
+    "category": "Normalization",
+    "description": "Batch normalization.",
+    "inputs": [
+      { "name": "input" },
+      { "name": "scale" },
+      { "name": "bias" },
+      { "name": "mean" },
+      { "name": "var" }
+    ]
+  },
+  {
+    "name": "Concat",
+    "module": "vxm",
+    "category": "Tensor",
+    "description": "Concatenate tensors along an axis."
+  },
+  {
+    "name": "Pad",
+    "module": "vxm",
+    "category": "Shape",
+    "description": "Pad a tensor.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Identity",
+    "module": "vxm",
+    "description": "Identity (pass-through).",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Constant",
+    "module": "vxm",
+    "category": "Constant",
+    "description": "A constant tensor."
+  },
+  {
+    "name": "Shape",
+    "module": "vxm",
+    "category": "Shape",
+    "description": "Return the shape of a tensor.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Gather",
+    "module": "vxm",
+    "category": "Transform",
+    "description": "Gather slices along an axis.",
+    "inputs": [
+      { "name": "data" },
+      { "name": "indices" }
+    ]
+  },
+  {
+    "name": "Unsqueeze",
+    "module": "vxm",
+    "category": "Transform",
+    "description": "Insert size-1 dimensions.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Unary",
+    "module": "vxm",
+    "description": "Element-wise unary op (see the operation attribute).",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Binary",
+    "module": "vxm",
+    "description": "Element-wise binary op (see the operation attribute).",
+    "inputs": [
+      { "name": "A" },
+      { "name": "B" }
+    ]
+  },
+  {
+    "name": "PRelu",
+    "module": "vxm",
+    "category": "Activation",
+    "description": "Parametric ReLU, per-channel slope.",
+    "inputs": [
+      { "name": "input" },
+      { "name": "slope" }
+    ]
+  },
+  {
+    "name": "Resize",
+    "module": "vxm",
+    "category": "Data",
+    "description": "Resize / upsample (nearest or linear).",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "GridSample",
+    "module": "vxm",
+    "description": "Sample input at grid coordinates.",
+    "inputs": [
+      { "name": "input" },
+      { "name": "grid" }
+    ]
+  },
+  {
+    "name": "Transpose",
+    "module": "vxm",
+    "category": "Transform",
+    "description": "Permute dimensions.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Slice",
+    "module": "vxm",
+    "category": "Tensor",
+    "description": "Strided slice.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Reduce",
+    "module": "vxm",
+    "description": "Reduction (mean/sum/max/min/prod/L2; see the operation attribute).",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "DepthToSpace",
+    "module": "vxm",
+    "category": "Shape",
+    "description": "Rearrange depth into spatial blocks.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Cast",
+    "module": "vxm",
+    "description": "Cast to a different data type.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Split",
+    "module": "vxm",
+    "category": "Tensor",
+    "description": "Split a tensor along an axis.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Where",
+    "module": "vxm",
+    "description": "Element-wise select, cond ? X : Y.",
+    "inputs": [
+      { "name": "condition" },
+      { "name": "X" },
+      { "name": "Y" }
+    ]
+  },
+  {
+    "name": "Equal",
+    "module": "vxm",
+    "description": "Element-wise equality.",
+    "inputs": [
+      { "name": "A" },
+      { "name": "B" }
+    ]
+  },
+  {
+    "name": "Greater",
+    "module": "vxm",
+    "description": "Element-wise greater-than.",
+    "inputs": [
+      { "name": "A" },
+      { "name": "B" }
+    ]
+  },
+  {
+    "name": "GreaterEqual",
+    "module": "vxm",
+    "description": "Element-wise greater-than-or-equal.",
+    "inputs": [
+      { "name": "A" },
+      { "name": "B" }
+    ]
+  },
+  {
+    "name": "ConstantOfShape",
+    "module": "vxm",
+    "category": "Constant",
+    "description": "Emit a tensor of a given shape filled with a scalar.",
+    "inputs": [
+      { "name": "shape" }
+    ]
+  },
+  {
+    "name": "EyeLike",
+    "module": "vxm",
+    "category": "Constant",
+    "description": "Identity-like matrix matching the input shape.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "ScatterND",
+    "module": "vxm",
+    "description": "Scatter update slices at N-D index rows.",
+    "inputs": [
+      { "name": "data" },
+      { "name": "indices" },
+      { "name": "updates" }
+    ]
+  },
+  {
+    "name": "FusedSE",
+    "module": "vxm",
+    "category": "Normalization",
+    "description": "Fused Squeeze-Excite scale (GAP -> FC -> relu -> FC -> hardsigmoid).",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "FusedDwPw",
+    "module": "vxm",
+    "category": "Layer",
+    "description": "Fused depthwise-3x3 + 1x1-project convolution.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "FusedPointwise",
+    "module": "vxm",
+    "description": "Fused per-element chain (a standalone unit or a producer's epilogue).",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "ConvertLayout",
+    "module": "vxm",
+    "category": "Shape",
+    "description": "Tensor layout conversion (inserted by the layout pass).",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "ConvertDtype",
+    "module": "vxm",
+    "description": "fp16<->fp32 storage conversion at a selective-fp32 region frontier.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "Range",
+    "module": "vxm",
+    "category": "Constant",
+    "description": "arange(start, limit, delta) -> 1-D output.",
+    "inputs": [
+      { "name": "start" },
+      { "name": "limit" },
+      { "name": "delta" }
+    ]
+  },
+  {
+    "name": "ConvGemm",
+    "module": "vxm",
+    "category": "Layer",
+    "description": "Conv lowered to an implicit-GEMM kernel; weights repacked [K][Cout].",
+    "inputs": [
+      { "name": "input" },
+      { "name": "weight" },
+      { "name": "bias" }
+    ]
+  },
+  {
+    "name": "Less",
+    "module": "vxm",
+    "description": "Element-wise less-than.",
+    "inputs": [
+      { "name": "A" },
+      { "name": "B" }
+    ]
+  },
+  {
+    "name": "LessEqual",
+    "module": "vxm",
+    "description": "Element-wise less-than-or-equal.",
+    "inputs": [
+      { "name": "A" },
+      { "name": "B" }
+    ]
+  },
+  {
+    "name": "Dropout",
+    "module": "vxm",
+    "description": "Identity in inference mode (eliminated at import).",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "TopK",
+    "module": "vxm",
+    "category": "Transform",
+    "description": "The k largest/smallest along an axis -> (values, int64 indices).",
+    "inputs": [
+      { "name": "input" },
+      { "name": "k" }
+    ]
+  },
+  {
+    "name": "InstanceNormalization",
+    "module": "vxm",
+    "category": "Normalization",
+    "description": "Per-channel normalization over the spatial dimensions.",
+    "inputs": [
+      { "name": "input" },
+      { "name": "scale" },
+      { "name": "bias" }
+    ]
+  },
+  {
+    "name": "QuantizeLinear",
+    "module": "vxm",
+    "category": "Quantization",
+    "description": "Quantize fp -> int8/uint8: saturate(round(x / scale) + zero_point).",
+    "inputs": [
+      { "name": "x" },
+      { "name": "scale" },
+      { "name": "zero_point" }
+    ]
+  },
+  {
+    "name": "DequantizeLinear",
+    "module": "vxm",
+    "category": "Quantization",
+    "description": "Dequantize int -> fp: (q - zero_point) * scale.",
+    "inputs": [
+      { "name": "x" },
+      { "name": "scale" },
+      { "name": "zero_point" }
+    ]
+  },
+  {
+    "name": "DynamicQuantizeLinear",
+    "module": "vxm",
+    "category": "Quantization",
+    "description": "Derive scale/zero-point from the input range -> (x_q u8, x_scale, x_zp).",
+    "inputs": [
+      { "name": "x" }
+    ]
+  },
+  {
+    "name": "QLinearConv",
+    "module": "vxm",
+    "category": "Quantization",
+    "description": "Convolution on int8 with per-input scale/zp and output requant.",
+    "inputs": [
+      { "name": "x" },
+      { "name": "x_scale" },
+      { "name": "x_zero_point" },
+      { "name": "w" },
+      { "name": "w_scale" },
+      { "name": "w_zero_point" },
+      { "name": "y_scale" },
+      { "name": "y_zero_point" },
+      { "name": "B" }
+    ]
+  },
+  {
+    "name": "QLinearMatMul",
+    "module": "vxm",
+    "category": "Quantization",
+    "description": "Matrix multiply on int8 with per-input scale/zp and output requant.",
+    "inputs": [
+      { "name": "a" },
+      { "name": "a_scale" },
+      { "name": "a_zero_point" },
+      { "name": "b" },
+      { "name": "b_scale" },
+      { "name": "b_zero_point" },
+      { "name": "y_scale" },
+      { "name": "y_zero_point" }
+    ]
+  },
+  {
+    "name": "QLinearAdd",
+    "module": "vxm",
+    "category": "Quantization",
+    "description": "com.microsoft: Add on int8 with per-input scale/zp and output requant.",
+    "inputs": [
+      { "name": "A" },
+      { "name": "A_scale" },
+      { "name": "A_zero_point" },
+      { "name": "B" },
+      { "name": "B_scale" },
+      { "name": "B_zero_point" },
+      { "name": "C_scale" },
+      { "name": "C_zero_point" }
+    ]
+  },
+  {
+    "name": "QLinearGlobalAveragePool",
+    "module": "vxm",
+    "category": "Quantization",
+    "description": "com.microsoft: GlobalAveragePool on int8 with x/y scale/zp.",
+    "inputs": [
+      { "name": "X" },
+      { "name": "x_scale" },
+      { "name": "x_zero_point" },
+      { "name": "y_scale" },
+      { "name": "y_zero_point" }
+    ]
+  },
+  {
+    "name": "MatMulInteger",
+    "module": "vxm",
+    "category": "Quantization",
+    "description": "int8 x int8 -> int32 MatMul, optional zero points.",
+    "inputs": [
+      { "name": "A" },
+      { "name": "B" },
+      { "name": "a_zero_point" },
+      { "name": "b_zero_point" }
+    ]
+  },
+  {
+    "name": "ConvInteger",
+    "module": "vxm",
+    "category": "Quantization",
+    "description": "int8 x int8 -> int32 Conv, optional zero points.",
+    "inputs": [
+      { "name": "x" },
+      { "name": "w" },
+      { "name": "x_zero_point" },
+      { "name": "w_zero_point" }
+    ]
+  },
+  {
+    "name": "QGemm",
+    "module": "vxm",
+    "category": "Quantization",
+    "description": "com.microsoft: Gemm on int8 with scales/zps and int32 bias.",
+    "inputs": [
+      { "name": "A" },
+      { "name": "a_scale" },
+      { "name": "a_zero_point" },
+      { "name": "B" },
+      { "name": "b_scale" },
+      { "name": "b_zero_point" },
+      { "name": "C" },
+      { "name": "y_scale" },
+      { "name": "y_zero_point" }
+    ]
+  },
+  {
+    "name": "IsNaN",
+    "module": "vxm",
+    "description": "Element-wise NaN test: float -> bool.",
+    "inputs": [
+      { "name": "input" }
+    ]
+  },
+  {
+    "name": "And",
+    "module": "vxm",
+    "description": "Element-wise boolean AND with NumPy broadcasting.",
+    "inputs": [
+      { "name": "A" },
+      { "name": "B" }
+    ]
+  },
+  {
+    "name": "RMSNorm",
+    "module": "vxm",
+    "category": "Normalization",
+    "description": "Root-mean-square norm: y = x * rsqrt(mean(x^2, last-axis) + eps) * gamma.",
+    "inputs": [
+      { "name": "input" },
+      { "name": "gamma" }
+    ]
+  },
+  {
+    "name": "SimplifiedLayerNormalization",
+    "module": "vxm",
+    "category": "Normalization",
+    "description": "com.microsoft RMSNorm spelling (input, gamma) with epsilon/axis.",
+    "inputs": [
+      { "name": "input" },
+      { "name": "gamma" }
+    ]
+  },
+  {
+    "name": "SkipSimplifiedLayerNormalization",
+    "module": "vxm",
+    "category": "Normalization",
+    "description": "com.microsoft: residual add + RMSNorm; output 3 is the residual sum.",
+    "inputs": [
+      { "name": "input" },
+      { "name": "skip" },
+      { "name": "gamma" },
+      { "name": "bias" }
+    ]
+  },
+  {
+    "name": "SkipLayerNormalization",
+    "module": "vxm",
+    "category": "Normalization",
+    "description": "com.microsoft: residual add + LayerNorm.",
+    "inputs": [
+      { "name": "input" },
+      { "name": "skip" },
+      { "name": "gamma" },
+      { "name": "beta" },
+      { "name": "bias" }
+    ]
+  },
+  {
+    "name": "RotaryEmbedding",
+    "module": "vxm",
+    "category": "Transform",
+    "description": "Rotary position embedding (RoPE) over (x, position_ids, cos_cache, sin_cache).",
+    "inputs": [
+      { "name": "input" },
+      { "name": "position_ids" },
+      { "name": "cos_cache" },
+      { "name": "sin_cache" }
+    ]
+  },
+  {
+    "name": "MultiHeadAttention",
+    "module": "vxm",
+    "category": "Attention",
+    "description": "com.microsoft fused multi-head attention (q/k/v with optional additive mask).",
+    "inputs": [
+      { "name": "query" },
+      { "name": "key" },
+      { "name": "value" },
+      { "name": "bias" },
+      { "name": "mask" }
+    ]
+  },
+  {
+    "name": "GroupQueryAttention",
+    "module": "vxm",
+    "category": "Attention",
+    "description": "com.microsoft fused GQA with in-op RoPE and a KV cache.",
+    "inputs": [
+      { "name": "query" },
+      { "name": "key" },
+      { "name": "value" },
+      { "name": "past_key" },
+      { "name": "past_value" },
+      { "name": "seqlens_k" },
+      { "name": "total_sequence_length" },
+      { "name": "cos_cache" },
+      { "name": "sin_cache" }
+    ]
+  },
+  {
+    "name": "MatMulNBits",
+    "module": "vxm",
+    "category": "Layer",
+    "description": "com.microsoft blockwise 4-bit weight MatMul (repacked into the int4 wq format).",
+    "inputs": [
+      { "name": "A" },
+      { "name": "B" },
+      { "name": "scales" },
+      { "name": "zero_points" }
+    ]
+  },
+  {
+    "name": "Rope",
+    "module": "vxm",
+    "category": "Transform",
+    "description": "Fused rotate-half rotary embedding (load-time fuseRope pass; never serialized).",
+    "inputs": [
+      { "name": "input" },
+      { "name": "position_ids" },
+      { "name": "cos_table" },
+      { "name": "sin_table" }
+    ]
+  },
+  {
+    "name": "FusedAttention",
+    "module": "vxm",
+    "category": "Attention",
+    "description": "Single-query decode attention core softmax(q.K^T * scale + mask).V in one kernel."
+  }
 ]

--- a/source/vknn.js
+++ b/source/vknn.js
@@ -2,6 +2,23 @@
 // Experimental
 //
 // https://github.com/katolikov/vknn
+//
+// Reads the vknn ".vxm" container: the engine's post-optimization graph serialization, whose byte
+// layout is defined by src/core/model_io.cpp in github.com/katolikov/vknn. The body is a custom
+// fixed-width little-endian binary (fwrite of pod/vec/str) -- NOT msgpack -- read here field for
+// field in the engine's exact write order.
+//
+// The parser is deliberately topology-first so that most future format bumps cost nothing here:
+//   * Dispatch is by container KIND, not a hardcoded magic. A base body is either one graph (VXM3)
+//     or several shape buckets (VXM4); a quantized wrapper (magic >= VXM5) is a [subtag: 3|4][base
+//     body], so a future wrapper magic that keeps that shape unwraps and reads with no new code.
+//     Each bucket becomes its own Netron module/graph, labelled by bucket name.
+//   * Weights are OPAQUE. An initializer is read as { name, shape, dtype, byteLength }; its payload
+//     bytes are skipped, never decoded. New weight-storage/quant formats (VXM5 int4, VXM6
+//     int8/lut4, ...) change only those skipped bytes, so they need no parser change here.
+//   * An unrecognized op type renders as a node by its numeric name, and an unrecognized dtype as
+//     'dtype#N', rather than throwing -- a newly added engine op then shows up automatically (just
+//     less decorated). vknn-metadata.json only ENRICHES the ops it already knows.
 
 const vknn = {};
 
@@ -11,7 +28,11 @@ vknn.ModelFactory = class {
         const stream = context.stream;
         if (stream && stream.length > 8) {
             const buffer = stream.peek(4);
-            if (buffer[0] === 0x56 && buffer[1] === 0x58 && buffer[2] === 0x4d && buffer[3] === 0x31) {
+            // Every container magic is ASCII "VXM<version>" little-endian, so the low three bytes
+            // spell "VXM" and the top byte is the version digit. Match any such file so an
+            // out-of-range version still reaches open() and reports a clean "incompatible version"
+            // message instead of falling through to a generic "unsupported format".
+            if (buffer[0] === 0x56 && buffer[1] === 0x58 && buffer[2] === 0x4d && buffer[3] >= 0x30 && buffer[3] <= 0x39) {
                 return context.set('vknn');
             }
         }
@@ -21,27 +42,28 @@ vknn.ModelFactory = class {
     async open(context) {
         const metadata = await context.metadata('vknn-metadata.json');
         const reader = await context.read('binary');
-        const graph = new vknn.Reader(reader);
-        return new vknn.Model(metadata, graph);
+        const container = new vknn.Reader(reader);
+        return new vknn.Model(metadata, container);
     }
 };
 
 vknn.Model = class {
 
-    constructor(metadata, graph) {
-        this.format = 'VKNN';
-        this.modules = [new vknn.Graph(metadata, graph)];
+    constructor(metadata, container) {
+        this.format = container.format;
+        // One Netron module per shape bucket (a single-graph VXM3/VXM6-sub3 file yields exactly one).
+        this.modules = container.buckets.map((bucket) => new vknn.Graph(metadata, container, bucket));
     }
 };
 
 vknn.Graph = class {
 
-    constructor(metadata, graph) {
-        this.name = '';
+    constructor(metadata, container, bucket) {
+        this.name = bucket.name || '';
         this.inputs = [];
         this.outputs = [];
         this.nodes = [];
-        const tensors = graph.tensors;
+        const tensors = bucket.tensors;
         const values = new Array(tensors.length);
         const value = (id) => {
             id = Number(id);
@@ -52,21 +74,21 @@ vknn.Graph = class {
                 const tensor = tensors[id];
                 const name = tensor.name && tensor.name.length > 0 ? tensor.name : id.toString();
                 const type = new vknn.TensorType(tensor.dtype, new vknn.TensorShape(tensor.shape), tensor.format);
-                const data = graph.initializers.get(id);
-                const initializer = data ? new vknn.Tensor(name, type, data) : null;
+                const weight = bucket.initializers.get(id);
+                const initializer = weight ? new vknn.Tensor(name, type, weight) : null;
                 values[id] = new vknn.Value(name, type, initializer);
             }
             return values[id];
         };
-        for (const id of graph.inputs) {
+        for (const id of bucket.inputs) {
             const argument = value(id);
             this.inputs.push(new vknn.Argument(argument ? argument.name : id.toString(), argument ? [argument] : []));
         }
-        for (const id of graph.outputs) {
+        for (const id of bucket.outputs) {
             const argument = value(id);
             this.outputs.push(new vknn.Argument(argument ? argument.name : id.toString(), argument ? [argument] : []));
         }
-        for (const node of graph.nodes) {
+        for (const node of bucket.nodes) {
             this.nodes.push(new vknn.Node(metadata, node, value));
         }
     }
@@ -96,68 +118,26 @@ vknn.Value = class {
 vknn.Node = class {
 
     constructor(metadata, node, value) {
-        let type = null;
-        switch (node.type) {
-            case 0: type = 'Unknown'; break;
-            case 1: type = 'Conv'; break;
-            case 2: type = 'Clip'; break;
-            case 3: type = 'Relu'; break;
-            case 4: type = 'Add'; break;
-            case 5: type = 'GlobalAvgPool'; break;
-            case 6: type = 'AvgPool'; break;
-            case 7: type = 'MaxPool'; break;
-            case 8: type = 'Gemm'; break;
-            case 9: type = 'MatMul'; break;
-            case 10: type = 'Einsum'; break;
-            case 11: type = 'Reshape'; break;
-            case 12: type = 'Expand'; break;
-            case 13: type = 'Tile'; break;
-            case 14: type = 'Squeeze'; break;
-            case 15: type = 'Flatten'; break;
-            case 16: type = 'Softmax'; break;
-            case 17: type = 'LayerNorm'; break;
-            case 18: type = 'BatchNorm'; break;
-            case 19: type = 'Concat'; break;
-            case 20: type = 'Pad'; break;
-            case 21: type = 'Identity'; break;
-            case 22: type = 'Constant'; break;
-            case 23: type = 'Shape'; break;
-            case 24: type = 'Gather'; break;
-            case 25: type = 'Unsqueeze'; break;
-            case 26: type = 'Unary'; break;
-            case 27: type = 'Binary'; break;
-            case 28: type = 'PRelu'; break;
-            case 29: type = 'Resize'; break;
-            case 30: type = 'GridSample'; break;
-            case 31: type = 'Transpose'; break;
-            case 32: type = 'Slice'; break;
-            case 33: type = 'Reduce'; break;
-            case 34: type = 'DepthToSpace'; break;
-            case 35: type = 'Cast'; break;
-            case 36: type = 'Split'; break;
-            case 37: type = 'Where'; break;
-            case 38: type = 'Equal'; break;
-            case 39: type = 'ConstantOfShape'; break;
-            case 40: type = 'EyeLike'; break;
-            case 41: type = 'ScatterND'; break;
-            case 42: type = 'FusedSE'; break;
-            case 43: type = 'FusedDwPw'; break;
-            case 44: type = 'ConvertLayout'; break;
-            default: type = node.type.toString(); break;
-        }
-        this.type = metadata.type(type);
+        const type = vknn.Utility.operator(node.type);
+        this.type = metadata.type(type) || { name: type };
         this.name = node.name || '';
         this.inputs = [];
         this.outputs = [];
         this.attributes = [];
         this.chain = [];
-        // A fused residual tensor is kept in node.inputs by the graph passes (for liveness/scheduling),
-        // but it is surfaced separately below as a named 'residual' input, so skip it here.
+        // A fused residual/bias tensor is kept in node.inputs by the graph passes (for liveness and
+        // scheduling), but each is surfaced separately below as a named 'residual'/'bias' input, so
+        // skip it in the positional input pass.
         const residual = Number(node.fusedResidual);
         const hasResidual = Number.isInteger(residual) && residual >= 0;
+        const bias = Number(node.fusedBias);
+        const hasBias = Number.isInteger(bias) && bias >= 0;
         const inputNames = Array.isArray(this.type.inputs) ? this.type.inputs.map((input) => input.name) : [];
         for (let i = 0; i < node.inputs.length; i++) {
             if (hasResidual && node.inputs[i] === residual) {
+                continue;
+            }
+            if (hasBias && node.inputs[i] === bias) {
                 continue;
             }
             const argument = value(node.inputs[i]);
@@ -183,22 +163,25 @@ vknn.Node = class {
             }
             this.attributes.push(new vknn.Argument(attr.name, content, kind));
         }
+        // Decode the packed-weight quantization tag (the kWq="wq" attr; engine
+        // core/quant_weights.h) into a readable format alongside the raw value, so a quantized
+        // node's weight storage (int4 / int8 / lut4) is visible.
+        const wq = node.attributes.find((attr) => attr.name === 'wq' && attr.kind === 1);
+        if (wq) {
+            const formats = { 1: 'int4', 2: 'int8', 3: 'lut4' };
+            this.attributes.push(new vknn.Argument('weight_quant', formats[wq.i] || `format#${wq.i}`, 'string'));
+        }
         if (node.fusedAct !== 0) {
-            const activations = ['None', 'Relu', 'Relu6', 'Clip', 'HardSwish', 'SiLU'];
-            const activation = node.fusedAct < activations.length ? activations[node.fusedAct] : node.fusedAct.toString();
-            this.attributes.push(new vknn.Argument('fused_activation', activation, 'string'));
+            this.attributes.push(new vknn.Argument('fused_activation', vknn.Utility.activation(node.fusedAct), 'string'));
             if (node.actLo !== 0 || node.actHi !== 0) {
                 this.attributes.push(new vknn.Argument('activation_min', node.actLo, 'float32'));
                 this.attributes.push(new vknn.Argument('activation_max', node.actHi, 'float32'));
             }
         }
-        let operation = null;
-        switch (type) {
-            case 'Unary': operation = ['Sigmoid', 'Tanh', 'HardSwish', 'HardSigmoid', 'LeakyRelu', 'Elu', 'Abs', 'Neg', 'Exp', 'Log', 'Sqrt', 'Floor', 'Ceil', 'Relu', 'SiLU', 'Erf', 'Cos', 'Sin', 'Reciprocal', 'Softplus'][node.subOp]; break;
-            case 'Binary': operation = ['Mul', 'Sub', 'Div', 'Max', 'Min', 'Pow', 'Add'][node.subOp]; break;
-            case 'Reduce': operation = ['Mean', 'Sum', 'Max', 'Min', 'Prod', 'L2'][node.subOp]; break;
-            default: break;
-        }
+        // Recover the specific op for the elementwise families that collapse onto one OpType, from
+        // the sub-op code the engine stores in Node::subOp (unary_type.h / binary_type.h /
+        // reduce_type.h).
+        const operation = vknn.Utility.subOperation(type, node.subOp);
         if (operation) {
             this.attributes.push(new vknn.Argument('operation', operation, 'string'));
         }
@@ -208,12 +191,20 @@ vknn.Node = class {
                 this.inputs.push(new vknn.Argument('residual', [argument]));
             }
         }
+        if (hasBias) {
+            const argument = value(bias);
+            if (argument) {
+                this.inputs.push(new vknn.Argument('bias', [argument]));
+            }
+        }
     }
 };
 
 vknn.TensorType = class {
 
     constructor(dtype, shape, format) {
+        // dtype.h DType codes. An unrecognized code shows as 'dtype#N' rather than throwing, so a
+        // future element type still renders (just unnamed).
         switch (dtype) {
             case 0: this.dataType = 'float32'; break;
             case 1: this.dataType = 'float16'; break;
@@ -221,10 +212,11 @@ vknn.TensorType = class {
             case 3: this.dataType = 'int8'; break;
             case 4: this.dataType = 'uint8'; break;
             case 5: this.dataType = 'int64'; break;
-            default: this.dataType = '?'; break;
+            default: this.dataType = `dtype#${dtype}`; break;
         }
         this.shape = shape;
-        // The IR is canonically NCHW, so only annotate a boundary tensor with a non-default layout.
+        // The IR is canonically NCHW (tensor_format_enum.h), so only annotate a boundary tensor
+        // whose stored layout is not the default.
         switch (format) {
             case 1: this.denotation = 'NHWC'; break;
             case 2: this.denotation = 'NC4HW4'; break;
@@ -255,21 +247,57 @@ vknn.TensorShape = class {
 
 vknn.Tensor = class {
 
-    constructor(name, type, data) {
+    constructor(name, type, weight) {
         this.name = name;
         this.type = type;
-        this.values = data;
+        // Weights are opaque: the payload bytes are never read from the file, so there is no data to
+        // decode. Netron renders the type/shape and shows "Tensor data is empty" for the value.
         this.encoding = '<';
+        this.values = null;
+        if (weight && Number.isFinite(weight.byteLength)) {
+            this.location = vknn.Utility.byteSize(weight.byteLength);
+        }
+        if (weight && weight.category) {
+            this.category = weight.category;
+        }
     }
 };
 
+// Reads a whole .vxm container into { buckets, format }. Each bucket is { name, tensors, nodes,
+// inputs, outputs, initializers }, where initializers maps a tensor id to { byteLength } (weights
+// stay opaque). The byte layout is model_io.cpp's Writer order, read little-endian.
 vknn.Reader = class {
 
     constructor(reader) {
         const magic = reader.uint32();
-        if (magic !== 0x314d5856) {
-            throw new vknn.Error(`Invalid magic number '0x${magic.toString(16)}'.`);
+        if ((magic & 0x00ffffff) !== 0x004d5856) { // low three bytes must be "VXM"
+            throw new vknn.Error(`Invalid magic number '0x${(magic >>> 0).toString(16).padStart(8, '0')}' (not a .vxm file).`);
         }
+        const version = (magic >>> 24) - 0x30; // 1..9 for "VXM1".."VXM9"
+        // Quantized wrapper (VXM5 = int4-only, VXM6 = int8/lut4/other; core/quant_weights.h): one
+        // subcontainer tag then the exact VXM3/VXM4 body. Remap to the base container and read that;
+        // a future wrapper magic with the same [subtag][body] shape reuses this path unchanged.
+        let base = magic;
+        let quant = '';
+        if (magic === 0x354d5856 || magic === 0x364d5856) {
+            quant = magic === 0x354d5856 ? 'int4' : 'int8/lut4';
+            const subtag = reader.uint32();
+            base = 0;
+            if (subtag === 3) {
+                base = 0x334d5856; // VXM3 single-graph body
+            } else if (subtag === 4) {
+                base = 0x344d5856; // VXM4 multi-bucket body
+            } else {
+                throw new vknn.Error(`Unsupported VKNN quantized subcontainer tag '${subtag}'.`);
+            }
+        }
+        if (base !== 0x334d5856 && base !== 0x344d5856) {
+            // A recognizable "VXM<n>" outside the readable set (VXM1/VXM2 legacy, or a newer bump)
+            // was written by an incompatible engine version; mirror model_io.cpp's diagnostic.
+            throw new vknn.Error(`VXM${version} container is from an incompatible vknn version (this build reads VXM3-VXM6) -- reconvert the model from its .onnx with the current vknn_compile.`);
+        }
+
+        // ---- primitive vector readers (little-endian; mirror Writer::vec/str in model_io.cpp) ----
         const int32s = () => {
             const length = reader.uint32();
             const values = new Array(length);
@@ -282,7 +310,7 @@ vknn.Reader = class {
             const length = reader.uint32();
             const values = new Array(length);
             for (let i = 0; i < length; i++) {
-                values[i] = reader.int64().toNumber();
+                values[i] = Number(reader.int64());
             }
             return values;
         };
@@ -294,59 +322,285 @@ vknn.Reader = class {
             }
             return values;
         };
-        const bytes = () => {
-            const length = reader.uint32();
-            return reader.read(length);
-        };
-        const tensorCount = reader.uint32();
-        this.tensors = new Array(tensorCount);
-        for (let i = 0; i < tensorCount; i++) {
-            const name = reader.string();
-            const shape = int64s();
-            const dtype = reader.uint32();
-            const format = reader.uint32();
-            const flags = reader.uint32();
-            this.tensors[i] = {
-                name, shape, dtype, format,
-                isInput: (flags & 1) !== 0,
-                isOutput: (flags & 2) !== 0,
-                isInitializer: (flags & 4) !== 0
-            };
-        }
-        const nodeCount = reader.uint32();
-        this.nodes = new Array(nodeCount);
-        for (let i = 0; i < nodeCount; i++) {
-            const type = reader.uint32();
-            const name = reader.string();
+
+        // Read the tensor/node/I-O tables of one graph body (writeGraphStructure in model_io.cpp).
+        // Initializers are read by the caller, because VXM3 inlines their bytes while VXM4 references
+        // a shared pool.
+        const readStructure = () => {
+            const tensorCount = reader.uint32();
+            const tensors = new Array(tensorCount);
+            for (let i = 0; i < tensorCount; i++) {
+                const name = reader.string();
+                const shape = int64s();
+                const dtype = reader.uint32();
+                const format = reader.uint32();
+                const flags = reader.uint32();
+                tensors[i] = {
+                    name, shape, dtype, format,
+                    isInput: (flags & 1) !== 0,
+                    isOutput: (flags & 2) !== 0,
+                    isInitializer: (flags & 4) !== 0
+                };
+            }
+            const nodeCount = reader.uint32();
+            const nodes = new Array(nodeCount);
+            for (let i = 0; i < nodeCount; i++) {
+                const type = reader.uint32();
+                const name = reader.string();
+                const inputs = int32s(); // TensorId == int32
+                const outputs = int32s();
+                const fusedAct = reader.uint32();
+                const actLo = reader.float32();
+                const actHi = reader.float32();
+                const subOp = Number(reader.int64());
+                const fusedResidual = Number(reader.int64());
+                const fusedBias = Number(reader.int64());
+                const attributeCount = reader.uint32();
+                const attributes = new Array(attributeCount);
+                for (let j = 0; j < attributeCount; j++) {
+                    const attrName = reader.string();
+                    const kind = reader.uint32();
+                    const i = Number(reader.int64());
+                    const f = reader.float32();
+                    const ints = int64s();
+                    const floats = float32s();
+                    const str = reader.string();
+                    attributes[j] = { name: attrName, kind, i, f, ints, floats, str };
+                }
+                nodes[i] = { type, name, inputs, outputs, fusedAct, actLo, actHi, subOp, fusedResidual, fusedBias, attributes };
+            }
             const inputs = int32s();
             const outputs = int32s();
-            const fusedAct = reader.uint32();
-            const actLo = reader.float32();
-            const actHi = reader.float32();
-            const subOp = reader.int64().toNumber();
-            const fusedResidual = reader.int64().toNumber();
-            const attributeCount = reader.uint32();
-            const attributes = new Array(attributeCount);
-            for (let j = 0; j < attributeCount; j++) {
-                const name = reader.string();
-                const kind = reader.uint32();
-                const i = reader.int64().toNumber();
-                const f = reader.float32();
-                const ints = int64s();
-                const floats = float32s();
-                const str = reader.string();
-                attributes[j] = { name, kind, i, f, ints, floats, str };
+            return { tensors, nodes, inputs, outputs };
+        };
+
+        this.buckets = [];
+        if (base === 0x334d5856) {
+            // VXM3 single-graph body: the structure, then inline initializers (tensor id + opaque
+            // byte blob). The payload bytes are skipped, never materialized.
+            const bucket = readStructure();
+            bucket.name = '';
+            bucket.initializers = new Map();
+            const initializerCount = reader.uint32();
+            for (let i = 0; i < initializerCount; i++) {
+                const id = Number(reader.int64());
+                const byteLength = reader.uint32();
+                reader.skip(byteLength);
+                bucket.initializers.set(id, { byteLength });
             }
-            this.nodes[i] = { type, name, inputs, outputs, fusedAct, actLo, actHi, subOp, fusedResidual, attributes };
+            this.buckets.push(bucket);
+        } else {
+            // VXM4 multi-bucket body: bucket count, a shared content-deduped initializer pool, then
+            // each bucket's structure + its (tensor id -> pool index) table. The pool bytes are
+            // skipped; only each blob's byte size is kept, so every bucket's weights resolve to
+            // { byteLength } through the pool index.
+            const bucketCount = reader.uint32();
+            const poolCount = reader.uint32();
+            const pool = new Array(poolCount);
+            for (let i = 0; i < poolCount; i++) {
+                const byteLength = reader.uint32();
+                reader.skip(byteLength);
+                pool[i] = { byteLength };
+            }
+            for (let b = 0; b < bucketCount; b++) {
+                const name = reader.string();
+                const bucket = readStructure();
+                bucket.name = name;
+                bucket.initializers = new Map();
+                const refCount = reader.uint32();
+                for (let i = 0; i < refCount; i++) {
+                    const id = Number(reader.int64());
+                    const poolIndex = reader.uint32();
+                    const blob = poolIndex < pool.length ? pool[poolIndex] : { byteLength: 0 };
+                    bucket.initializers.set(id, { byteLength: blob.byteLength });
+                }
+                this.buckets.push(bucket);
+            }
         }
-        this.inputs = int32s();
-        this.outputs = int32s();
-        const initializerCount = reader.uint32();
-        this.initializers = new Map();
-        for (let i = 0; i < initializerCount; i++) {
-            const id = reader.int64().toNumber();
-            this.initializers.set(id, bytes());
+
+        // Container label: version + quantization + bucket count (e.g. "VKNN v5 (int4, 2 buckets)").
+        const notes = [];
+        if (quant) {
+            notes.push(quant);
         }
+        if (this.buckets.length > 1) {
+            notes.push(`${this.buckets.length} buckets`);
+        }
+        this.format = notes.length > 0 ? `VKNN v${version} (${notes.join(', ')})` : `VKNN v${version}`;
+    }
+};
+
+vknn.Utility = class {
+
+    // OpType (include/vknn/op_type.h) is APPEND-ONLY, so the enum's integer value is a stable index
+    // into this table; the spellings are the engine's own opTypeName() (src/core/op.cpp), which are
+    // ONNX-style, so vknn-metadata.json enriches them by the same name. An index past the table
+    // renders as 'Op#N' -- a newly added engine op shows up automatically, just undecorated.
+    static operator(type) {
+        vknn.Utility._operators = vknn.Utility._operators || [
+            'Unknown',                          // 0
+            'Conv',                             // 1
+            'ConvTranspose',                    // 2
+            'Clip',                             // 3
+            'Relu',                             // 4
+            'Add',                              // 5
+            'GlobalAveragePool',                // 6
+            'AveragePool',                      // 7
+            'MaxPool',                          // 8
+            'Gemm',                             // 9
+            'MatMul',                           // 10
+            'Einsum',                           // 11
+            'Reshape',                          // 12
+            'Expand',                           // 13
+            'Tile',                             // 14
+            'Squeeze',                          // 15
+            'Flatten',                          // 16
+            'Softmax',                          // 17
+            'LayerNormalization',               // 18
+            'BatchNormalization',               // 19
+            'Concat',                           // 20
+            'Pad',                              // 21
+            'Identity',                         // 22
+            'Constant',                         // 23
+            'Shape',                            // 24
+            'Gather',                           // 25
+            'Unsqueeze',                        // 26
+            'Unary',                            // 27
+            'Binary',                           // 28
+            'PRelu',                            // 29
+            'Resize',                           // 30
+            'GridSample',                       // 31
+            'Transpose',                        // 32
+            'Slice',                            // 33
+            'Reduce',                           // 34
+            'DepthToSpace',                     // 35
+            'Cast',                             // 36
+            'Split',                            // 37
+            'Where',                            // 38
+            'Equal',                            // 39
+            'Greater',                          // 40
+            'GreaterEqual',                     // 41
+            'ConstantOfShape',                  // 42
+            'EyeLike',                          // 43
+            'ScatterND',                        // 44
+            'FusedSE',                          // 45
+            'FusedDwPw',                        // 46
+            'FusedPointwise',                   // 47
+            'ConvertLayout',                    // 48
+            'ConvertDtype',                     // 49
+            'Range',                            // 50
+            'ConvGemm',                         // 51
+            'Less',                             // 52
+            'LessEqual',                        // 53
+            'Dropout',                          // 54
+            'TopK',                             // 55
+            'InstanceNormalization',            // 56
+            'QuantizeLinear',                   // 57
+            'DequantizeLinear',                 // 58
+            'DynamicQuantizeLinear',            // 59
+            'QLinearConv',                      // 60
+            'QLinearMatMul',                    // 61
+            'QLinearAdd',                       // 62
+            'QLinearGlobalAveragePool',         // 63
+            'MatMulInteger',                    // 64
+            'ConvInteger',                      // 65
+            'QGemm',                            // 66
+            'IsNaN',                            // 67
+            'And',                              // 68
+            'RMSNorm',                          // 69
+            'SimplifiedLayerNormalization',     // 70
+            'SkipSimplifiedLayerNormalization', // 71
+            'SkipLayerNormalization',           // 72
+            'RotaryEmbedding',                  // 73
+            'MultiHeadAttention',               // 74
+            'GroupQueryAttention',              // 75
+            'MatMulNBits',                      // 76
+            'Rope',                             // 77
+            'FusedAttention'                    // 78
+        ];
+        const operators = vknn.Utility._operators;
+        return type >= 0 && type < operators.length ? operators[type] : `Op#${type}`;
+    }
+
+    // Fused-activation name for an ActType code (act_type.h). An unrecognized code shows as its
+    // number.
+    static activation(code) {
+        vknn.Utility._activations = vknn.Utility._activations || [
+            'None',      // 0
+            'Relu',      // 1
+            'Relu6',     // 2
+            'Clip',      // 3
+            'HardSwish', // 4
+            'SiLU'       // 5
+        ];
+        const activations = vknn.Utility._activations;
+        return code >= 0 && code < activations.length ? activations[code] : code.toString();
+    }
+
+    // The specific op an elementwise family (Unary/Binary/Reduce) resolves to, from the sub-op code
+    // the engine stores in Node::subOp. The tables are the engine's own enum orders (unary_type.h /
+    // binary_type.h / reduce_type.h); an out-of-range code returns null (no attribute emitted).
+    static subOperation(family, code) {
+        vknn.Utility._subOperations = vknn.Utility._subOperations || {
+            Unary: [
+                'Sigmoid',    // 0
+                'Tanh',       // 1
+                'HardSwish',  // 2
+                'HardSigmoid',// 3
+                'LeakyRelu',  // 4
+                'Elu',        // 5
+                'Abs',        // 6
+                'Neg',        // 7
+                'Exp',        // 8
+                'Log',        // 9
+                'Sqrt',       // 10
+                'Floor',      // 11
+                'Ceil',       // 12
+                'Relu',       // 13
+                'SiLU',       // 14
+                'Erf',        // 15
+                'Cos',        // 16
+                'Sin',        // 17
+                'Reciprocal', // 18
+                'Softplus',   // 19
+                'Round',      // 20
+                'Trunc'       // 21
+            ],
+            Binary: [
+                'Mul', // 0
+                'Sub', // 1
+                'Div', // 2
+                'Max', // 3
+                'Min', // 4
+                'Pow', // 5
+                'Add'  // 6
+            ],
+            Reduce: [
+                'Mean', // 0
+                'Sum',  // 1
+                'Max',  // 2
+                'Min',  // 3
+                'Prod', // 4
+                'L2'    // 5
+            ]
+        };
+        const table = vknn.Utility._subOperations[family];
+        return table && code >= 0 && code < table.length ? table[code] : null;
+    }
+
+    // Compact human-readable byte count for a weight's on-disk size.
+    static byteSize(bytes) {
+        if (bytes < 1024) {
+            return `${bytes} B`;
+        }
+        const units = ['KB', 'MB', 'GB', 'TB'];
+        let value = bytes / 1024;
+        let unit = 0;
+        while (value >= 1024 && unit < units.length - 1) {
+            value /= 1024;
+            unit++;
+        }
+        return `${value.toFixed(2)} ${units[unit]}`;
     }
 };
 

--- a/test/models.json
+++ b/test/models.json
@@ -9064,14 +9064,14 @@
     "type":     "vknn",
     "target":   "squeezenet.vxm",
     "source":   "https://raw.githubusercontent.com/katolikov/vknn/main/samples/squeezenet.vxm",
-    "format":   "VKNN",
+    "format":   "VKNN v3",
     "link":     "https://github.com/lutzroeder/netron/pull/1581"
   },
   {
     "type":     "vknn",
     "target":   "squeezenet_fp16.vxm",
     "source":   "https://raw.githubusercontent.com/katolikov/vknn/main/samples/squeezenet_fp16.vxm",
-    "format":   "VKNN",
+    "format":   "VKNN v3",
     "link":     "https://github.com/lutzroeder/netron/pull/1581"
   },
   {


### PR DESCRIPTION
Follow-up to #1581, which added the VKNN (`.vxm`) format. The engine's on-disk format has since moved from `VXM1` to `VXM3`–`VXM6`, so the reader as merged opens none of the files the current compiler produces. This brings it current.

VKNN is a small GPU inference engine (https://github.com/katolikov/vknn); a `.vxm` is its self-contained, post-optimization graph — a fixed-width little-endian binary defined by `src/core/model_io.cpp` in that repo.

## What changed

- **Dispatch by container kind.** Reads `VXM3` (single graph) and `VXM4` (multi-bucket, shared initializer pool), and unwraps the quantized wrappers `VXM5` (int4) and `VXM6` (int8 / lut4), each a `[subtag][base body]`. Each bucket is surfaced as its own module, and a future wrapper of the same shape needs no further change.
- **Opaque weights.** Initializers are read as `{name, shape, dtype, byteLength}` and their payloads skipped, never decoded — new weight/quant formats don't touch the parser, and multi-GB models stream rather than load into memory.
- **Never throws on unknown input.** An unrecognized op renders as `Op#N`, an unknown dtype as `dtype#N`. The op / dtype / activation tables and `vknn-metadata.json` are reconciled with the engine's current operator set.
- **Supporting fixes.** Add `StreamReader.string()` (missing on the >512 MB reader path) and route every `VXM` magic to the loader.
