### PR TITLE
fix: correct Falied→Failed typo in flatc error message

### DIFF
--- a/tools/flatc.js
+++ b/tools/flatc.js
@@ -327,7 +327,7 @@ flatc.TypeReference = class {
         if (type) {
             return type;
         }
-        throw new flatc.Error(`Falied to resolve type '${this.name}'.`);
+        throw new flatc.Error(`Failed to resolve type '${this.name}'.`);
     }
 };
 


### PR DESCRIPTION
Corrects `Falied` → `Failed` typo in tools/flatc.js line 330.

This is a user-facing error message thrown when flatc fails to resolve a type.

```javascript
// Before
throw new flatc.Error(`Falied to resolve type '${this.name}'.`);

// After
throw new flatc.Error(`Failed to resolve type '${this.name}'.`);
```

1 file, 1 line change.