### PR TITLE
Add a postMessage embedding protocol to the browser host

### DIFF
--- a/docs/embedding-example.html
+++ b/docs/embedding-example.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Netron embedding example</title>
+    <style>
+        body { font-family: sans-serif; margin: 1em; }
+        #row { display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap; margin-bottom: 0.5em; }
+        #origin { width: 22em; }
+        #status { color: #555; margin-bottom: 0.5em; min-height: 1.2em; }
+        iframe { width: 100%; height: 80vh; border: 1px solid #ccc; }
+    </style>
+</head>
+<body>
+    <!--
+      Manual test for the postMessage embedding protocol (see embedding.md).
+      Pick a model file; it is read in-page and handed to the embedded Netron as
+      raw bytes over postMessage — nothing is uploaded. Point "Netron origin" at
+      a build that includes the protocol (e.g. this fork's preview deployment);
+      upstream netron.app will not respond to the handshake until it ships.
+    -->
+    <div id="row">
+        <label>Netron origin: <input id="origin" value="https://netron.app"></label>
+        <input id="file" type="file">
+    </div>
+    <div id="status">Pick a model file to load it into the embedded Netron.</div>
+    <iframe id="frame" title="Netron"></iframe>
+
+    <script>
+        const originInput = document.getElementById("origin");
+        const fileInput = document.getElementById("file");
+        const frame = document.getElementById("frame");
+        const status = document.getElementById("status");
+
+        function loadIntoNetron(buffer, name) {
+            const origin = originInput.value.replace(/\/+$/, "");
+            status.textContent = `Loading ${name} (${buffer.byteLength} bytes)…`;
+            frame.src = origin + "/";
+
+            const onMessage = (e) => {
+                if (e.source !== frame.contentWindow) {
+                    return;
+                }
+                if (e.data === "PONG") {
+                    clearInterval(ping);
+                    // Transfer the buffer to hand off large models without a copy.
+                    frame.contentWindow.postMessage({ netron: { buffer, name } }, origin, [buffer]);
+                } else if (e.data && e.data.netron && e.data.netron.status) {
+                    clearInterval(ping);
+                    window.removeEventListener("message", onMessage);
+                    status.textContent = e.data.netron.status === "success"
+                        ? `Loaded ${name}.`
+                        : `Error: ${e.data.netron.message}`;
+                }
+            };
+            window.addEventListener("message", onMessage);
+            // Netron ignores pings sent before it is ready, so keep pinging.
+            const ping = setInterval(() => {
+                if (frame.contentWindow) {
+                    frame.contentWindow.postMessage("PING", origin);
+                }
+            }, 50);
+        }
+
+        fileInput.addEventListener("change", async (e) => {
+            const file = e.target.files && e.target.files[0];
+            if (file) {
+                loadIntoNetron(await file.arrayBuffer(), file.name);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -10,7 +10,11 @@ path fails — `about:blank#blocked` — for any model over ~1.5&nbsp;MB).
 
 ## Protocol
 
-1. Open Netron in a popup (`window.open`) or an `<iframe>`.
+1. Open Netron in a popup (`window.open`) or an `<iframe>`. Load it with the
+   `?embed` query flag (e.g. `https://netron.app/?embed`) so it runs in
+   **embedded mode** — the first-run update/cookie-consent dialogs and
+   telemetry are suppressed, since an embedder is driving the window and a user
+   may not be present to dismiss a dialog.
 2. Post the string `'PING'` to it repeatedly. Netron replies with the string
    `'PONG'` once it is ready to receive a model. (It stays silent to pings sent
    before it is ready, so keep pinging on an interval until the first `'PONG'`.)

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,0 +1,94 @@
+# Embedding Netron
+
+Netron's web build can be embedded in another page and handed a model
+**directly as bytes**, over `window.postMessage`, without uploading it anywhere
+or squeezing it into the URL. This mirrors
+[Perfetto's embedding protocol](https://perfetto.dev/docs/visualization/embedding-the-ui)
+and exists specifically to get around the browser URL-length limit (Chromium
+blocks navigations to URLs longer than ~2&nbsp;MB, so the `#<data-url>` loading
+path fails — `about:blank#blocked` — for any model over ~1.5&nbsp;MB).
+
+## Protocol
+
+1. Open Netron in a popup (`window.open`) or an `<iframe>`.
+2. Post the string `'PING'` to it repeatedly. Netron replies with the string
+   `'PONG'` once it is ready to receive a model. (It stays silent to pings sent
+   before it is ready, so keep pinging on an interval until the first `'PONG'`.)
+3. Once you receive `'PONG'`, stop pinging and post a single request:
+
+   ```js
+   target.postMessage({
+     netron: {
+       buffer,          // ArrayBuffer or typed array — the raw model bytes
+       name: 'model.onnx', // display name; its extension drives format detection
+       // identifier: 'model.onnx', // optional; defaults to `name`
+       // url: 'https://…',          // optional; only used to resolve sidecar files
+     }
+   }, targetOrigin);
+   ```
+
+4. Netron opens the model and posts back
+   `{ netron: { status: 'success', identifier } }` or
+   `{ netron: { status: 'error', message } }`.
+
+`buffer` is transferable — pass it in the second `postMessage` argument
+(`postMessage(msg, targetOrigin, [buffer])`) to hand off large models without a
+copy.
+
+## Example — popup
+
+```js
+function openInNetron(bytes, name, netronOrigin = 'https://netron.app') {
+  const win = window.open(netronOrigin);
+  const onMessage = (e) => {
+    if (e.source !== win) {
+      return;
+    }
+    if (e.data === 'PONG') {
+      clearInterval(ping);
+      const buffer = bytes.buffer ? bytes.buffer : bytes; // accept a view or an ArrayBuffer
+      win.postMessage({ netron: { buffer, name } }, netronOrigin, [buffer]);
+    } else if (e.data && e.data.netron && e.data.netron.status) {
+      window.removeEventListener('message', onMessage);
+      if (e.data.netron.status === 'error') {
+        console.error('Netron failed to open the model:', e.data.netron.message);
+      }
+    }
+  };
+  window.addEventListener('message', onMessage);
+  const ping = setInterval(() => win.postMessage('PING', netronOrigin), 50);
+}
+```
+
+## Example — iframe
+
+```js
+const frame = document.createElement('iframe');
+frame.src = 'https://netron.app';
+document.body.appendChild(frame);
+
+const target = frame.contentWindow;
+const onMessage = (e) => {
+  if (e.source !== target) {
+    return;
+  }
+  if (e.data === 'PONG') {
+    clearInterval(ping);
+    target.postMessage({ netron: { buffer, name: 'model.onnx' } }, '*', [buffer]);
+  }
+};
+window.addEventListener('message', onMessage);
+const ping = setInterval(() => target.postMessage('PING', '*'), 50);
+```
+
+## Notes
+
+- **Nothing is uploaded.** The bytes travel in-process between windows of the
+  same browser; Netron loads them from memory.
+- **Origins.** Netron answers a ping to `event.source` using the ping's own
+  `event.origin`, and accepts a model from any origin (it only *renders* a
+  model, it never executes it). Send your model with the most specific
+  `targetOrigin` you can rather than `'*'`.
+- **Readiness.** Netron only answers `'PING'` after its view is initialized —
+  which can be delayed by a first-run cookie-consent prompt — so the ping loop
+  is required; a single ping may be missed.

--- a/source/browser.js
+++ b/source/browser.js
@@ -34,6 +34,15 @@ browser.Host = class {
         if (this.version && !/^\d+\.\d+\.\d+$/.test(this.version)) {
             throw new Error('Invalid version.');
         }
+        // Cross-window embedding protocol (see docs/embedding.md), modeled on
+        // Perfetto's: an embedder posts a model straight into this window/frame
+        // as raw bytes, sidestepping the browser URL-length limit that caps the
+        // '#<data-url>' loading path. The listener is installed here, as early
+        // as possible, but only answers once the host is ready (see start()),
+        // so the handshake can't hand a model to a half-initialized view.
+        this._ready = false;
+        this._pending = null;
+        this._window.addEventListener('message', (e) => this._receive(e));
     }
 
     get window() {
@@ -145,6 +154,17 @@ browser.Host = class {
     }
 
     async start() {
+        // The view is fully wired up by the time start() runs, so it is now
+        // safe to answer the embedding handshake and open a posted model. If a
+        // model arrived early (before the handshake completed), open it now
+        // instead of falling through to the welcome screen.
+        this._ready = true;
+        if (this._pending) {
+            const e = this._pending;
+            this._pending = null;
+            await this._openRequest(e);
+            return;
+        }
         if (this._meta.file) {
             const [url] = this._meta.file;
             if (this._view.accept(url)) {
@@ -218,6 +238,73 @@ browser.Host = class {
             }
         });
         this._view.show('welcome');
+    }
+
+    // Dispatch an incoming window message for the embedding protocol. An
+    // embedder first posts the string 'PING' repeatedly until it receives
+    // 'PONG', which signals the host is ready; it then posts
+    // `{ netron: { buffer, name, identifier, url } }` to load a model. Both the
+    // 'PONG' reply and the load are deferred until the host is ready so a
+    // compliant embedder never races the view's initialization. Messages that
+    // are neither a ping nor a `netron` request are ignored, so this coexists
+    // with unrelated postMessage traffic (extensions, dev tooling, etc.).
+    _receive(e) {
+        const message = e.data;
+        if (message === 'PING') {
+            if (this._ready && e.source) {
+                const origin = e.origin && e.origin !== 'null' ? e.origin : '*';
+                e.source.postMessage('PONG', origin);
+            }
+            return;
+        }
+        if (message && typeof message === 'object' && message.netron && message.netron.buffer !== undefined) {
+            if (this._ready) {
+                this._openRequest(e);
+            } else {
+                this._pending = e;
+            }
+        }
+    }
+
+    // Open a model handed over by an embedder as raw bytes and, when possible,
+    // report the outcome back to the embedder as
+    // `{ netron: { status: 'success' | 'error', ... } }`.
+    async _openRequest(e) {
+        const request = e.data.netron;
+        const origin = e.origin && e.origin !== 'null' ? e.origin : '*';
+        const respond = (status, detail) => {
+            if (e.source) {
+                e.source.postMessage({ netron: { status, ...detail } }, origin);
+            }
+        };
+        this._view.show('welcome spinner');
+        try {
+            let buffer = request.buffer;
+            if (buffer instanceof ArrayBuffer) {
+                buffer = new Uint8Array(buffer);
+            } else if (ArrayBuffer.isView(buffer)) {
+                buffer = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+            } else {
+                throw new Error("Expected 'buffer' to be an ArrayBuffer or a typed array.");
+            }
+            // Netron detects the format from the identifier's extension (with a
+            // content fallback), so prefer a name like 'model.onnx'.
+            const identifier = request.identifier || request.name || request.title || 'model';
+            const name = request.name || request.title || null;
+            const stream = new base.BinaryStream(buffer);
+            const context = new browser.Context(this, request.url || '', identifier, name, stream);
+            const status = await this._openContext(context);
+            if (status === '') {
+                respond('success', { identifier });
+            } else {
+                this._view.show('welcome');
+                respond('error', { message: `Unable to open model (${status}).` });
+            }
+        } catch (error) {
+            await this._view.error(error, 'Model load request failed.');
+            this._view.show('welcome');
+            respond('error', { message: error && error.message ? error.message : String(error) });
+        }
     }
 
     environment(name) {

--- a/source/browser.js
+++ b/source/browser.js
@@ -43,6 +43,14 @@ browser.Host = class {
         this._ready = false;
         this._pending = null;
         this._window.addEventListener('message', (e) => this._receive(e));
+        // Embedded mode (loaded with `?embed`): an embedder drives this window
+        // via the message protocol, so suppress the update/consent dialogs and
+        // telemetry that would otherwise sit in front of the model or fire
+        // without a user present. Skipping telemetry() leaves the telemetry
+        // session unstarted, so all send() calls no-op on their own.
+        const search = this._window.location.search;
+        const params = search ? new this._window.URLSearchParams(search) : null;
+        this._embedded = params ? params.has('embed') : false;
     }
 
     get window() {
@@ -147,9 +155,11 @@ browser.Host = class {
             });
             return Promise.resolve();
         };
-        await age();
-        await consent();
-        await telemetry();
+        if (!this._embedded) {
+            await age();
+            await consent();
+            await telemetry();
+        }
         await capabilities();
     }
 

--- a/source/mlir-metadata.json
+++ b/source/mlir-metadata.json
@@ -2062,7 +2062,7 @@
       { "name": "ptr", "type": "LLVM_AnyPointer" },
       { "name": "mask", "type": "I1" },
       { "name": "falseVal", "type": "LLVM_Type" },
-      { "name": "multicastMask", "type": "Optional<I16>" }
+      { "name": "multicastMask", "type": "Optional<I32>" }
     ],
     "results": [
       { "name": "result", "type": "LLVM_Type" }
@@ -25816,6 +25816,7 @@
       { "name": "res_attrs", "type": "OptionalAttr<TypedArrayAttrBase<DictionaryAttr>>" },
       { "name": "branch_weights", "type": "OptionalAttr<DenseI32ArrayAttr>" },
       { "name": "CConv", "type": "DefaultValuedAttr<CConv, CConv::C>" },
+      { "name": "default_func_attrs", "type": "OptionalAttr<DictionaryAttr>" },
       { "name": "op_bundle_sizes", "type": "DenseI32ArrayAttr" },
       { "name": "op_bundle_tags", "type": "OptionalAttr<ArrayAttr>" }
     ],
@@ -64190,6 +64191,13 @@
     "assemblyFormat": "(`(` $optional^ `:` type($optional) `)`)? `:` type($optional_res)\n  (`[` $variadic^ `]`)? attr-dict"
   },
   {
+    "name": "test.format_optional_operand_type",
+    "operands": [
+      { "name": "optional", "type": "Optional<AnyType>" }
+    ],
+    "assemblyFormat": "(`(` $optional^ `)`)?\n    (`:` type($optional)^)?\n    attr-dict"
+  },
+  {
     "name": "test.format_optional_prop_dict",
     "attributes": [
       { "name": "a", "type": "OptionalProp<StringProp>" },
@@ -67191,6 +67199,21 @@
       { "type": "AttrSizedOperandSegments" }
     ],
     "assemblyFormat": "$a1 `:` $a2 `:` type($b1) `:` type($b2) prop-dict attr-dict `end`"
+  },
+  {
+    "name": "test.variadic_segment_prop_bulk_type",
+    "operands": [
+      { "name": "a1", "type": "Variadic<I64>" },
+      { "name": "a2", "type": "Variadic<I64>" }
+    ],
+    "results": [
+      { "name": "b1", "type": "Variadic<I64>" },
+      { "name": "b2", "type": "Variadic<I64>" }
+    ],
+    "traits": [
+      { "type": "AttrSizedOperandSegments" }
+    ],
+    "assemblyFormat": "`(` operands `)` `:` functional-type(operands, results) prop-dict attr-dict"
   },
   {
     "name": "test.variadic_with_same_operand_results",
@@ -81639,12 +81662,12 @@
     "summary": "DynamicUpdateSlice.",
     "description": "DynamicUpdateSlice op that have the same semantics with XLA\n    DynamicUpdateSlice.\n    Generates a result which is the value of the input array\n    operand, with a slice update overwritten at start_indices.\n\n    See https://www.tensorflow.org/xla/operation_semantics#dynamicupdateslice.",
     "operands": [
-      { "name": "operand", "type": "TFL_TensorOf<[I1, TFL_I4, QI4, QI8, I8, I16, I32, I64, F32, F16]>" },
-      { "name": "update", "type": "TFL_TensorOf<[I1, TFL_I4, QI4, QI8, I8, I16, I32, I64, F32, F16]>" },
+      { "name": "operand", "type": "TFL_TensorOf<[I1, TFL_I4, QI4, QI8, I8, I16, I32, I64, F32, F16, BF16]>" },
+      { "name": "update", "type": "TFL_TensorOf<[I1, TFL_I4, QI4, QI8, I8, I16, I32, I64, F32, F16, BF16]>" },
       { "name": "start_indices", "type": "TFL_I32OrI64Tensor" }
     ],
     "results": [
-      { "name": "output", "type": "TFL_TensorOf<[I1, TFL_I4, QI4, QI8, I8, I16, I32, I64, F32, F16]>" }
+      { "name": "output", "type": "TFL_TensorOf<[I1, TFL_I4, QI4, QI8, I8, I16, I32, I64, F32, F16, BF16]>" }
     ]
   },
   {
@@ -83205,11 +83228,11 @@
     "summary": "Transpose operator",
     "description": "Returns the Transpose of x",
     "operands": [
-      { "name": "input", "type": "TFL_TensorOf<[I32, F32, F16, I8, UI8, QI8, QUI8, TFL_I4, QI4, TFL_Quint8, I1, I64, QI16]>" },
+      { "name": "input", "type": "TFL_TensorOf<[I32, F32, F16, BF16, I8, UI8, QI8, QUI8, TFL_I4, QI4, TFL_Quint8, I1, I64, QI16]>" },
       { "name": "perm", "type": "TFL_TensorOf<[I32]>" }
     ],
     "results": [
-      { "name": "output", "type": "TFL_TensorOf<[I32, F32, F16, I8, UI8, QI8, QUI8, TFL_I4, QI4, TFL_Quint8, I1, I64, QI16]>" }
+      { "name": "output", "type": "TFL_TensorOf<[I32, F32, F16, BF16, I8, UI8, QI8, QUI8, TFL_I4, QI4, TFL_Quint8, I1, I64, QI16]>" }
     ]
   },
   {
@@ -117055,13 +117078,10 @@
   {
     "name": "ttir.fill_cache",
     "summary": "Cache filling operation.",
-    "description": "The `fill_cache` operation fills a cache tensor with values from an input tensor.\n\n    Unlike `update_cache` which updates specific positions, this operation fills the entire cache\n    or a contiguous section of it with values from the input tensor. This is commonly used to\n    initialize a cache in sequence models.\n\n    Example:\n    ```mlir\n    // Fill cache with input values\n    %cache = ... : tensor<2x16x64xf32>  // Batch size 2, sequence length 16, hidden dim 64\n    %input = ... : tensor<2x16x64xf32>  // Initial values for the entire cache\n    %result = ttir.fill_cache(%cache, %input) {batch_offset = 0 : i32} :\n        tensor<2x16x64xf32>, tensor<2x16x64xf32> -> tensor<2x16x64xf32>\n    // The entire cache tensor is filled with values from input\n\n    // Fill a portion of the cache\n    %cache = ... : tensor<2x16x64xf32>  // Batch size 2, sequence length 16, hidden dim 64\n    %input = ... : tensor<2x8x64xf32>   // Values for half of the cache\n    %result = ttir.fill_cache(%cache, %input) {batch_offset = 0 : i32} :\n        tensor<2x16x64xf32>, tensor<2x8x64xf32> -> tensor<2x16x64xf32>\n    // The first 8 positions of the cache are filled with values from input\n    ```\n\n    Inputs:\n    - `cache` (Tensor): The cache tensor to be filled.\n    - `input` (Tensor): The input tensor containing the values to fill the cache with.\n\n    Attributes:\n    - `batch_offset` (Integer): Offset in the batch dimension.\n\n    Output:\n    - `result` (Tensor): The filled cache tensor.",
+    "description": "The `fill_cache` operation fills a cache tensor with values from an input tensor.\n\n    Unlike `update_cache` which updates specific positions, this operation fills the entire cache\n    or a contiguous section of it with values from the input tensor. This is commonly used to\n    initialize a cache in sequence models.\n\n    Example:\n    ```mlir\n    // Fill cache with input values\n    %cache = ... : tensor<2x16x64xf32>  // Batch size 2, sequence length 16, hidden dim 64\n    %input = ... : tensor<2x16x64xf32>  // Initial values for the entire cache\n    ttir.fill_cache(%cache, %input) {batch_offset = 0 : i32} :\n        tensor<2x16x64xf32>, tensor<2x16x64xf32>\n    // The entire cache tensor is filled in place with values from input\n\n    // Fill a portion of the cache\n    %cache = ... : tensor<2x16x64xf32>  // Batch size 2, sequence length 16, hidden dim 64\n    %input = ... : tensor<2x8x64xf32>   // Values for half of the cache\n    ttir.fill_cache(%cache, %input) {batch_offset = 0 : i32} :\n        tensor<2x16x64xf32>, tensor<2x8x64xf32>\n    // The first 8 positions of the cache are filled in place with values from input\n    ```\n\n    This op mutates `cache` in place and produces no result.\n\n    Inputs:\n    - `cache` (Tensor): The cache tensor to be filled in place.\n    - `input` (Tensor): The input tensor containing the values to fill the cache with.\n\n    Attributes:\n    - `batch_offset` (Integer): Offset in the batch dimension.",
     "operands": [
       { "name": "cache", "type": "AnyRankedTensor" },
       { "name": "input", "type": "AnyRankedTensor" }
-    ],
-    "results": [
-      { "name": "result", "type": "AnyRankedTensor" }
     ],
     "attributes": [
       { "name": "batch_offset", "type": "I32Attr" }
@@ -117763,9 +117783,6 @@
       { "name": "input", "type": "AnyRankedTensor" },
       { "name": "page_table", "type": "AnyRankedTensor" },
       { "name": "batch_idx_tensor", "type": "Optional<AnyRankedTensor>" }
-    ],
-    "results": [
-      { "name": "result", "type": "AnyRankedTensor" }
     ]
   },
   {
@@ -117822,15 +117839,12 @@
   {
     "name": "ttir.paged_update_cache",
     "summary": "Paged update cache op.",
-    "description": "Inputs:\n        - `cache`: The cache tensor to be updated. This tensor is modified in place [max_num_blocks, num_heads, block_size, head_dim]\n        - `input`: The input tensor containing new values. [1, num_users, num_heads (padded to 32), head_dim]\n        - `update_index`: Indices specifying where to update the cache. [num_users]\n        - `share_cache`: Whether the cache tensors share memory regions. Defaults to False.\n        - `page_table`: The page table for managing memory regions during updates. [num_users, max_num_blocks_per_seq]\n\n      Outputs:\n        - `result`: The updated cache tensor.",
+    "description": "Inputs:\n        - `cache`: The cache tensor to be updated. This tensor is modified in place [max_num_blocks, num_heads, block_size, head_dim]\n        - `input`: The input tensor containing new values. [1, num_users, num_heads (padded to 32), head_dim]\n        - `update_index`: Indices specifying where to update the cache. [num_users]\n        - `share_cache`: Whether the cache tensors share memory regions. Defaults to False.\n        - `page_table`: The page table for managing memory regions during updates. [num_users, max_num_blocks_per_seq]\n\n      This op mutates `cache` in place and produces no result.",
     "operands": [
       { "name": "cache", "type": "AnyRankedTensor" },
       { "name": "input", "type": "AnyRankedTensor" },
       { "name": "update_index", "type": "AnyRankedTensor" },
       { "name": "page_table", "type": "Optional<AnyRankedTensor>" }
-    ],
-    "results": [
-      { "name": "result", "type": "AnyRankedTensor" }
     ],
     "attributes": [
       { "name": "share_cache", "type": "DefaultValuedAttr<BoolAttr, false>" }
@@ -118696,14 +118710,11 @@
   {
     "name": "ttir.update_cache",
     "summary": "Cache update operation.",
-    "description": "The `update_cache` operation updates a cache tensor with values from an input tensor at specific indices.\n\n    This operation is commonly used in sequence models like transformers to update a key-value cache\n    with new token information. It takes a cache tensor, an input tensor, and update indices, and\n    updates the cache at the specified positions.\n\n    Example:\n    ```mlir\n    // Update cache at specific indices\n    %cache = ... : tensor<2x16x64xf32>  // Batch size 2, sequence length 16, hidden dim 64\n    %input = ... : tensor<2x1x64xf32>   // New token embeddings\n    %update_index = ... : tensor<1xi32> // Update at position [15]\n    %result = ttir.update_cache(%cache, %input, %update_index) {batch_offset = 0 : i32} :\n        tensor<2x16x64xf32>, tensor<2x1x64xf32>, tensor<1xi32> -> tensor<2x16x64xf32>\n    // The cache tensor is updated at position 15 for both batches with the values from input\n    ```\n\n    Inputs:\n    - `cache` (Tensor): The cache tensor to be updated.\n    - `input` (Tensor): The input tensor containing new values.\n    - `update_index` (Tensor): Indices specifying where to update the cache.\n\n    Attributes:\n    - `batch_offset` (Integer): Offset in the batch dimension.\n\n    Output:\n    - `result` (Tensor): The updated cache tensor.",
+    "description": "The `update_cache` operation updates a cache tensor with values from an input tensor at specific indices.\n\n    This operation is commonly used in sequence models like transformers to update a key-value cache\n    with new token information. It takes a cache tensor, an input tensor, and update indices, and\n    updates the cache at the specified positions.\n\n    Example:\n    ```mlir\n    // Update cache at specific indices\n    %cache = ... : tensor<2x16x64xf32>  // Batch size 2, sequence length 16, hidden dim 64\n    %input = ... : tensor<2x1x64xf32>   // New token embeddings\n    %update_index = ... : tensor<1xi32> // Update at position [15]\n    ttir.update_cache(%cache, %input, %update_index) {batch_offset = 0 : i32} :\n        tensor<2x16x64xf32>, tensor<2x1x64xf32>, tensor<1xi32>\n    // The cache tensor is updated in place at position 15 for both batches with the values from input\n    ```\n\n    This op mutates `cache` in place and produces no result.\n\n    Inputs:\n    - `cache` (Tensor): The cache tensor to be updated in place.\n    - `input` (Tensor): The input tensor containing new values.\n    - `update_index` (Tensor): Indices specifying where to update the cache.\n\n    Attributes:\n    - `batch_offset` (Integer): Offset in the batch dimension.",
     "operands": [
       { "name": "cache", "type": "AnyRankedTensor" },
       { "name": "input", "type": "AnyRankedTensor" },
       { "name": "update_index", "type": "AnyRankedTensor" }
-    ],
-    "results": [
-      { "name": "result", "type": "AnyRankedTensor" }
     ],
     "attributes": [
       { "name": "batch_offset", "type": "I32Attr" }
@@ -122513,6 +122524,21 @@
     "assemblyFormat": "$alloc attr-dict `:` qualified(type($alloc))"
   },
   {
+    "name": "ttng.packed_arith",
+    "summary": "Apply elementwise arithmetic using a packed PTX instruction",
+    "description": "Applies packed x2, mixed-precision, and FP8/FP4/UE8M0 x4 arithmetic.\n    Instruction types, modifiers, and grouping are inferred from tensor types.\n    FP4 uses lower-nibble-first i8 values along the inferred halved dimension.",
+    "operands": [
+      { "name": "operands", "type": "Variadic<RankedTensorOf<[ TTNG_PackedArithOperandElement ]>>" }
+    ],
+    "results": [
+      { "name": "result", "type": "RankedTensorOf<[TTNG_PackedArithResultElement]>" }
+    ],
+    "attributes": [
+      { "name": "op_kind", "type": "TTNG_PackedArithOpKindAttr{add|sub|mul|fma|min|max}" }
+    ],
+    "assemblyFormat": "$op_kind $operands attr-dict `:` functional-type($operands, $result)"
+  },
+  {
     "name": "ttng.reinterpret_tensor_descriptor",
     "summary": "Reinterpret a pointer as a tensor descriptor",
     "description": "This op exists to help the transition from untyped raw TMA objects to typed tensor descriptor objects.\n     Ideally, we can remove this once the APIs are fully fleshed out.",
@@ -122742,7 +122768,7 @@
   {
     "name": "ttng.warp_group_dot_wait",
     "summary": "warp group dot wait",
-    "description": "Waits until there are $pendings or fewer outstanding async dot operations.\n\n    $inputs must be the tensors corresponding to the async dot ops that we're\n    waiting on. For example, if there are N pending async dot ops and we wait\n    until one remains pending, then $inputs must include the results of the\n    first N - 1 dot ops.",
+    "description": "Waits until there are $pendings or fewer outstanding async dot operations.\n\n    $inputs must be the tensors corresponding to the async dot ops that we're\n    waiting on. For example, if there are N pending async dot ops and we wait\n    until one remains pending, then $inputs must include the results of the\n    first N - 1 dot ops.\n\n    The `warpGroupLocal` attribute specifies that we only wait for the local\n    warp group, and if num_warps > 4 then shared memory inputs may still be in\n    use by other warp groups. This is useful when only the result register\n    values need to be ready and the shared memory inputs will not be overwritten.",
     "operands": [
       { "name": "inputs", "type": "Variadic<TTG_TensorOrMemDesc>" }
     ],
@@ -122750,7 +122776,8 @@
       { "name": "outputs", "type": "Variadic<TTG_TensorOrMemDesc>" }
     ],
     "attributes": [
-      { "name": "pendings", "type": "I32Attr" }
+      { "name": "pendings", "type": "I32Attr" },
+      { "name": "warpGroupLocal", "type": "UnitAttr" }
     ],
     "traits": [
       { "type": "AllTypesMatch<['inputs', 'outputs']>" }
@@ -137286,7 +137313,6 @@
       { "name": "sym_name", "type": "SymbolNameAttr" },
       { "name": "function_type", "type": "TypeAttrOf<FunctionType>" },
       { "name": "arg_attrs", "type": "OptionalAttr<TypedArrayAttrBase<DictionaryAttr>>" },
-      { "name": "tile_info", "type": "OptionalAttr<XTile_TilingInfoAttr>" },
       { "name": "res_attrs", "type": "OptionalAttr<TypedArrayAttrBase<DictionaryAttr>>" },
       { "name": "num_opaque_args", "type": "DefaultValuedAttr<I32Attr, 0>" }
     ],


### PR DESCRIPTION
## Summary

Rel https://github.com/lutzroeder/netron/issues/697 https://github.com/onnxsim/onnxsim/pull/519
Needed in model preview on https://onnxsim.github.io/onnxsim/ .

Lets an embedder hand a model to the web build of Netron **directly as bytes**
over `window.postMessage`, without uploading it or packing it into the URL.
This is modeled on
[Perfetto's embedding protocol](https://perfetto.dev/docs/visualization/embedding-the-ui).

The motivation is the browser URL-length limit: Chromium refuses to navigate to
URLs longer than ~2 MB (`about:blank#blocked`), so the existing
`#<data-url>` loading path fails for any model over ~1.5 MB. Passing the bytes
through a message channel removes that ceiling and keeps everything in-process —
nothing is uploaded.

## Protocol

1. The embedder opens Netron in a popup or `<iframe>`, ideally with the `?embed`
   flag (see below), and posts the string `"PING"` on an interval.
2. Netron replies `"PONG"` once its view is ready to receive a model.
3. The embedder posts `{ netron: { buffer, name, identifier, url } }`, where
   `buffer` is an `ArrayBuffer`/typed array of the raw model bytes.
4. Netron opens it and posts back `{ netron: { status: "success", identifier } }`
   or `{ netron: { status: "error", message } }`.

The bytes are loaded through the same in-memory path `_openGist` already uses
(`BinaryStream` → `Context` → `_openContext`).

## Changes

- **`source/browser.js`**
  - Install a `message` listener in the constructor, but only answer once the
    view is initialized (`start()`), so the handshake can never hand a model to
    a half-initialized view. A model that arrives early is stashed and opened
    when `start()` runs.
  - Reply `"PONG"` to `"PING"`; accept a `{ netron: { … } }` request; ignore all
    other `postMessage` traffic (extensions, dev tooling) by shape.
  - **Embedded mode** (`?embed`): suppress the first-run update/cookie-consent
    dialogs and skip telemetry startup, so an embedder can drive the window with
    no dialog in front of the model and no analytics firing without a user
    present. Skipping telemetry leaves the session unstarted, so `send()` no-ops
    on its own.
- **`docs/embedding.md`** — protocol spec with popup and iframe examples.
- **`docs/embedding-example.html`** — a runnable manual-test page (pick a file →
  embed Netron → handshake → load), with a configurable origin field.

## Notes

- Netron only *renders* a model (never executes it), so the request is accepted
  from any origin; `"PONG"` is sent back to `event.source` at the ping's own
  `event.origin`.
- No behavior change to the normal URL/`gist`/drag-drop loading paths, or to any
  non-web (Electron/Python) host.

## Testing

- `npm run lint` clean.
- `node package.js build web` builds; embedded mode present in the output.
- Manual: served the `web` build, drove it via `docs/embedding-example.html`
  (iframe + popup), verified the PING/PONG handshake and model load in embedded
  mode.