### PR TITLE
Fix visualization of nested lists of Keras tensors

### DIFF
--- a/source/keras.js
+++ b/source/keras.js
@@ -723,16 +723,19 @@ keras.Graph = class {
                                         }
                                     }
                                 } else if (inbound_node && inbound_node.args) {
-                                    for (const arg of inbound_node.args) {
-                                        if (arg && arg.class_name === '__keras_tensor__' && arg.config && is_connection(arg.config.keras_history)) {
+                                    const is_keras_tensor = (item) => item && item.class_name === '__keras_tensor__' && item.config && is_connection(item.config.keras_history);
+                                    const collect = (arg) => {
+                                        if (is_keras_tensor(arg)) {
                                             const key = read_connection(arg.config.keras_history);
                                             node.inputs.push({ name: key });
-                                        } else if (Array.isArray(arg) && arg.every((arg) => arg && arg.class_name === '__keras_tensor__' && arg.config && is_connection(arg.config.keras_history))) {
-                                            for (const input of arg) {
-                                                const key = read_connection(input.config.keras_history);
-                                                node.inputs.push({ name: key });
+                                        } else if (Array.isArray(arg)) {
+                                            for (const item of arg) {
+                                                collect(item);
                                             }
                                         }
+                                    };
+                                    for (const arg of inbound_node.args) {
+                                        collect(arg);
                                     }
                                 }
                             };


### PR DESCRIPTION
# Problem
Netron is showing specific models with lists of lists of tensors as unconnected graphs. See graph (and `.keras` model in the [attached zip file](https://github.com/user-attachments/files/30793077/create_example_model.zip)).
<img width="302" height="176" alt="image" src="https://github.com/user-attachments/assets/6a0e2fb9-5bfd-4999-bcbb-bb2e38e0a6f3" />
The existing logic only handles a single tensor or a flat list of tensors (arg.every(...)), so nested structures were silently dropped, leaving those layers with missing input edges.

# Fix
I've replaced the flat check with a recursive helper that is able to walk arrays of arrays and collects every Keras tensor as an input. The behavior for single tensors or flat lists is unchanged. With this fix the same graph as above looks the following:
<img width="253" height="231" alt="image" src="https://github.com/user-attachments/assets/e8f418f0-5fce-41f4-add3-4d5008d16607" />

# Reproduce the issue
Open the .keras file in the [attached zip file](https://github.com/user-attachments/files/30793077/create_example_model.zip) in Netron.