### PR TITLE
Add support for GML files

### DIFF
--- a/source/base.js
+++ b/source/base.js
@@ -1422,6 +1422,7 @@ base.Metadata = class {
             'dlc', 'uff', 'armnn', 'kann', 'kgraph', 'tosa',
             'ms', 'mindir', 'om',
             'mnn', 'ncnn', 'tm', 'mge', 'tmfile', 'tnnproto', 'xmodel', 'kmodel', 'rknn', 'espdl',
+            'dot', 'gml',
             'tar', 'zip'
         ];
     }

--- a/source/gml.js
+++ b/source/gml.js
@@ -1,0 +1,393 @@
+
+const gml = {};
+
+// https://en.wikipedia.org/wiki/Graph_Modelling_Language
+
+gml.ModelFactory = class {
+
+    async match(context) {
+        const reader = await context.read('text', 0x10000);
+        if (reader) {
+            try {
+                for (let i = 0; i < 64; i++) {
+                    const line = reader.read('\n');
+                    if (line === undefined) {
+                        break;
+                    }
+                    const trimmed = line.trim();
+                    if (trimmed.length === 0 || trimmed.startsWith('#')) {
+                        continue;
+                    }
+                    if (/^graph\s*\[$/.test(trimmed)) {
+                        return context.set('gml');
+                    }
+                    if (/^[A-Za-z][A-Za-z0-9_]*\s+("([^"\\]|\\.)*"|[+-]?[\d.]+)$/.test(trimmed)) {
+                        continue;
+                    }
+                    break;
+                }
+            } catch {
+                // continue regardless of error
+            }
+        }
+        return null;
+    }
+
+    async open(context) {
+        const decoder = await context.read('text.decoder');
+        const parser = new gml.Parser(decoder);
+        const entries = parser.parse();
+        return new gml.Model(entries);
+    }
+};
+
+gml.Model = class {
+
+    constructor(entries) {
+        this.format = 'GML';
+        const graphEntry = entries.find((entry) => entry.key === 'graph');
+        if (!graphEntry || !Array.isArray(graphEntry.value)) {
+            throw new gml.Error("File does not contain a 'graph' section.");
+        }
+        const creator = entries.find((entry) => entry.key === 'Creator');
+        if (creator && typeof creator.value === 'string') {
+            this.producer = creator.value;
+        }
+        const version = entries.find((entry) => entry.key === 'Version');
+        if (version && version.value !== undefined && version.value !== null) {
+            this.version = version.value.toString();
+        }
+        this.metadata = [];
+        for (const entry of graphEntry.value) {
+            if (entry.key !== 'node' && entry.key !== 'edge') {
+                const value = Array.isArray(entry.value) ? gml.Utility.map(entry.value) : entry.value;
+                this.metadata.push(new gml.Argument(entry.key, value));
+            }
+        }
+        this.modules = [new gml.Graph(graphEntry.value)];
+    }
+};
+
+gml.Graph = class {
+
+    constructor(entries) {
+        this.name = '';
+        this.inputs = [];
+        this.outputs = [];
+        this.nodes = [];
+        this.groups = true;
+        const nodes = new Map();
+        const groupLabels = new Map();
+        for (const entry of entries) {
+            if (entry.key === 'node') {
+                const map = gml.Utility.map(entry.value);
+                const id = map.get('id');
+                if (id === undefined || id === null) {
+                    continue;
+                }
+                if (map.get('isGroup')) {
+                    const label = map.get('label');
+                    if (typeof label === 'string' && label.length > 0) {
+                        groupLabels.set(id, label);
+                    }
+                    continue;
+                }
+                if (!nodes.has(id)) {
+                    nodes.set(id, { id, map, inputs: [], outputs: [] });
+                }
+            }
+        }
+        const values = new Map();
+        const value = (id) => {
+            if (!values.has(id)) {
+                values.set(id, new gml.Value(id.toString()));
+            }
+            return values.get(id);
+        };
+        for (const entry of entries) {
+            if (entry.key === 'edge') {
+                const map = gml.Utility.map(entry.value);
+                const source = map.get('source');
+                const target = map.get('target');
+                const from = nodes.get(source);
+                const to = nodes.get(target);
+                if (!from || !to) {
+                    continue;
+                }
+                const argument = value(source);
+                if (argument.metadata.length === 0) {
+                    for (const [key, val] of map) {
+                        if (key !== 'source' && key !== 'target') {
+                            argument.metadata.push(new gml.Argument(key, val));
+                        }
+                    }
+                }
+                if (!from.outputs.includes(argument)) {
+                    from.outputs.push(argument);
+                }
+                to.inputs.push(argument);
+            }
+        }
+        for (const [id, node] of nodes) {
+            this.nodes.push(new gml.Node(id, node, groupLabels));
+        }
+    }
+};
+
+gml.Argument = class {
+
+    constructor(name, value, type = null) {
+        this.name = name;
+        this.value = value;
+        this.type = type;
+    }
+};
+
+gml.Value = class {
+
+    constructor(name) {
+        this.name = name;
+        this.type = null;
+        this.initializer = null;
+        this.metadata = [];
+    }
+};
+
+gml.Node = class {
+
+    constructor(id, node, groupLabels) {
+        const map = node.map;
+        const label = map.get('label');
+        const name = map.get('name');
+        const opType = map.get('op_type');
+        this.name = gml.Node._title(label) || gml.Node._title(name) || `node${id}`;
+        if (typeof opType === 'string' && opType.length > 0) {
+            this.type = { name: opType, category: gml.Node._category(opType) };
+        } else if (map.get('is_buffer')) {
+            this.type = { name: 'Buffer', category: 'Constant' };
+        } else {
+            this.type = { name: gml.Node._title(label) || gml.Node._title(name) || 'Node' };
+        }
+        const gid = map.get('gid');
+        if (gid !== undefined && gid !== null && groupLabels && groupLabels.has(gid)) {
+            this.group = groupLabels.get(gid);
+        }
+        this.attributes = [];
+        for (const [key, value] of map) {
+            if (key === 'id' || key === 'op_type') {
+                continue;
+            }
+            this.attributes.push(new gml.Argument(key, value, 'attribute'));
+        }
+        this.inputs = node.inputs.map((value, index) => new gml.Argument(index.toString(), [value]));
+        this.outputs = node.outputs.map((value, index) => new gml.Argument(index.toString(), [value]));
+    }
+
+    static _title(text) {
+        if (typeof text !== 'string' || text.length === 0) {
+            return null;
+        }
+        return text.split('&#10;')[0].split('\n')[0].trim();
+    }
+
+    static _category(opType) {
+        const name = opType.toLowerCase();
+        for (const [regex, category] of gml.Node._categories) {
+            if (regex.test(name)) {
+                return category;
+            }
+        }
+        return 'Layer';
+    }
+};
+
+gml.Node._categories = [
+    [/(quantize|dequantize|quant)/, 'Quantization'],
+    [/attention/, 'Attention'],
+    [/(batchnorm|layernorm|rmsnorm|instancenorm|groupnorm|normalization|^norm)/, 'Normalization'],
+    [/(relu|sigmoid|tanh|gelu|silu|swish|softmax|prelu|leakyrelu|elu|clip|hardswish|hardsigmoid|activation)/, 'Activation'],
+    [/(maxpool|avgpool|averagepool|globalpool|^pool)/, 'Pool'],
+    [/dropout/, 'Dropout'],
+    [/(reshape|transpose|flatten|squeeze|unsqueeze|permute|^view|split|concat|slice|^pad|gather|scatter|tile|expand|upsample|resize|interp)/, 'Shape'],
+];
+
+gml.Utility = class {
+
+    static map(entries) {
+        const map = new Map();
+        for (const entry of entries) {
+            const value = Array.isArray(entry.value) ? gml.Utility.map(entry.value) : entry.value;
+            if (map.has(entry.key)) {
+                const existing = map.get(entry.key);
+                if (Array.isArray(existing)) {
+                    existing.push(value);
+                } else {
+                    map.set(entry.key, [existing, value]);
+                }
+            } else {
+                map.set(entry.key, value);
+            }
+        }
+        return map;
+    }
+};
+
+gml.Parser = class {
+
+    constructor(decoder) {
+        this._tokenizer = new gml.Tokenizer(decoder);
+    }
+
+    parse() {
+        return this._parseList(true);
+    }
+
+    _parseList(root) {
+        const list = [];
+        for (;;) {
+            const token = this._tokenizer.peek();
+            if (token.kind === 'eof') {
+                if (root) {
+                    break;
+                }
+                throw new gml.Error(`Unexpected end of input ${this._tokenizer.location()}`);
+            }
+            if (token.kind === ']') {
+                if (root) {
+                    throw new gml.Error(`Unexpected ']' ${this._tokenizer.location()}`);
+                }
+                break;
+            }
+            if (token.kind !== 'key') {
+                throw new gml.Error(`Expected key ${this._tokenizer.location()}`);
+            }
+            const key = this._tokenizer.read().value;
+            const next = this._tokenizer.peek();
+            let value = null;
+            if (next.kind === '[') {
+                this._tokenizer.read();
+                value = this._parseList(false);
+                const close = this._tokenizer.read();
+                if (close.kind !== ']') {
+                    throw new gml.Error(`Expected ']' ${this._tokenizer.location()}`);
+                }
+            } else if (next.kind === 'number' || next.kind === 'string') {
+                value = this._tokenizer.read().value;
+            } else {
+                throw new gml.Error(`Expected value ${this._tokenizer.location()}`);
+            }
+            list.push({ key, value });
+        }
+        return list;
+    }
+};
+
+gml.Tokenizer = class {
+
+    constructor(decoder) {
+        this._decoder = decoder;
+        this._position = 0;
+        this._char = this._decoder.decode();
+        this._token = null;
+    }
+
+    peek() {
+        if (!this._token) {
+            this._token = this._next();
+        }
+        return this._token;
+    }
+
+    read() {
+        const token = this.peek();
+        this._token = null;
+        return token;
+    }
+
+    location() {
+        return `at ${this._position}.`;
+    }
+
+    _next() {
+        for (;;) {
+            while (this._char !== undefined && /\s/.test(this._char)) {
+                this._advance();
+            }
+            if (this._char === '#') {
+                while (this._char !== undefined && this._char !== '\n') {
+                    this._advance();
+                }
+                continue;
+            }
+            break;
+        }
+        this._position = this._decoder.position;
+        if (this._char === undefined) {
+            return { kind: 'eof' };
+        }
+        if (this._char === '[' || this._char === ']') {
+            const value = this._char;
+            this._advance();
+            return { kind: value, value };
+        }
+        if (this._char === '"') {
+            this._advance();
+            let value = '';
+            while (this._char !== undefined && this._char !== '"') {
+                if (this._char === '\\') {
+                    this._advance();
+                    if (this._char === undefined) {
+                        break;
+                    }
+                    if (this._char === 'n') {
+                        value += '\n';
+                    } else if (this._char === 't') {
+                        value += '\t';
+                    } else {
+                        value += this._char;
+                    }
+                } else {
+                    value += this._char;
+                }
+                this._advance();
+            }
+            if (this._char !== '"') {
+                throw new gml.Error(`Unterminated string ${this.location()}`);
+            }
+            this._advance();
+            return { kind: 'string', value };
+        }
+        let value = '';
+        while (this._char !== undefined && !/[\s[\]"#]/.test(this._char)) {
+            value += this._char;
+            this._advance();
+        }
+        if (value.length === 0) {
+            throw new gml.Error(`Unexpected character '${this._char}' ${this.location()}`);
+        }
+        if (/^[+-]?\d+$/.test(value)) {
+            return { kind: 'number', value: parseInt(value, 10) };
+        }
+        if (/^[+-]?(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?$/.test(value)) {
+            return { kind: 'number', value: parseFloat(value) };
+        }
+        if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
+            return { kind: 'key', value };
+        }
+        return { kind: 'string', value };
+    }
+
+    _advance() {
+        this._char = this._decoder.decode();
+    }
+};
+
+gml.Error = class extends Error {
+
+    constructor(message) {
+        super(message);
+        this.name = 'Error loading GML graph';
+    }
+};
+
+export const ModelFactory = gml.ModelFactory;

--- a/source/grapher.css
+++ b/source/grapher.css
@@ -79,7 +79,8 @@
 .edge-path-tunnel { stroke-dasharray: 5, 3; marker-end: url("#arrowhead-tunnel"); opacity: 0.5; }
 #arrowhead-tunnel { fill: #000; }
 
-.cluster rect { stroke: #000; fill: #000; fill-opacity: 0.02; stroke-opacity: 0.06; stroke-width: 1px; }
+.cluster rect { stroke: #5b6b78; fill: #5b6b78; fill-opacity: 0.14; stroke-opacity: 0.65; stroke-width: 1.5px; stroke-dasharray: 4, 2; }
+.cluster-label { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "Ubuntu", "Droid Sans", sans-serif, "PingFang SC"; font-size: 11px; fill: #46535e; user-select: none; pointer-events: none; }
 
 .node-block > .node-block-background { fill: #fff; stroke: none; stroke-width: 0; }
 .node-block .edge-path { stroke: #000; stroke-width: 1px; fill: none; }
@@ -155,4 +156,7 @@
 
     .edge-path-tunnel { stroke: #888; opacity: 0.5; }
     #arrowhead-tunnel { fill: #888; }
+
+    .cluster rect { stroke: #9aabb8; fill: #9aabb8; fill-opacity: 0.18; stroke-opacity: 0.55; }
+    .cluster-label { fill: #c3ccd3; }
 }

--- a/source/grapher.js
+++ b/source/grapher.js
@@ -180,6 +180,12 @@ grapher.Graph = class {
                 node.element = document.createElementNS('http://www.w3.org/2000/svg', 'g');
                 node.element.setAttribute('class', 'cluster');
                 node.element.appendChild(node.rectangle);
+                if (node.label) {
+                    node.labelElement = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+                    node.labelElement.setAttribute('class', 'cluster-label');
+                    node.labelElement.textContent = node.label;
+                    node.element.appendChild(node.labelElement);
+                }
                 clusterGroup.appendChild(node.element);
             }
         }
@@ -350,6 +356,10 @@ grapher.Graph = class {
                 node.rectangle.setAttribute('y', - node.height / 2);
                 node.rectangle.setAttribute('width', node.width);
                 node.rectangle.setAttribute('height', node.height);
+                if (node.labelElement) {
+                    node.labelElement.setAttribute('x', - node.width / 2 + 6);
+                    node.labelElement.setAttribute('y', - node.height / 2 + 14);
+                }
             }
         }
         for (const edge of this.edges.values()) {

--- a/source/view.js
+++ b/source/view.js
@@ -2026,7 +2026,8 @@ view.Graph = class extends grapher.Graph {
             }
             const createCluster = (name) => {
                 if (!clusters.has(name)) {
-                    this.setNode({ name, rx: 5, ry: 5 });
+                    const label = name.split('\n')[0].split('/').pop();
+                    this.setNode({ name, label, rx: 5, ry: 5 });
                     clusters.add(name);
                     const parent = clusterParentMap.get(name);
                     if (parent) {
@@ -7298,6 +7299,7 @@ view.ModelFactoryService = class {
         this.register('./hailo', ['.hn', '.har', '.metadata.json']);
         this.register('./tvm', ['.json', '.params']);
         this.register('./dot', ['.dot'], [], [/^\s*(\/\*[\s\S]*?\*\/|\/\/.*|#.*)?\s*digraph\s*([A-Za-z][A-Za-z0-9-_]*|".*?")?\s*{/m]);
+        this.register('./gml', ['.gml'], [], [/^\s*(#.*\r?\n\s*)*graph\s*\[/m]);
         this.register('./jax', ['.jax', '.jax_export', '.jax_exported']);
         this.register('./catboost', ['.cbm', '.pkl'], [], [/^CBM1/]);
         this.register('./weka', ['.model']);

--- a/test/assets/gml/grouped_residual_block.gml
+++ b/test/assets/gml/grouped_residual_block.gml
@@ -1,0 +1,80 @@
+Creator "Netron GML Example"
+Version "1.0"
+graph [
+  directed 1
+  node [
+    id 100
+    isGroup 1
+    label "ResidualBlock"
+  ]
+  node [
+    id 0
+    label "input"
+    op_type "Input"
+  ]
+  node [
+    id 1
+    label "conv_a"
+    op_type "Conv"
+    gid 100
+    kernel_shape "3x3"
+  ]
+  node [
+    id 2
+    label "relu_a"
+    op_type "Relu"
+    gid 100
+  ]
+  node [
+    id 3
+    label "conv_b"
+    op_type "Conv"
+    gid 100
+    kernel_shape "3x3"
+  ]
+  node [
+    id 4
+    label "weight_const"
+    is_buffer 1
+    shape "64x64x3x3"
+    dtype "float32"
+  ]
+  node [
+    id 5
+    label "add"
+    op_type "Add"
+  ]
+  node [
+    id 6
+    label "output"
+    op_type "Output"
+  ]
+  edge [
+    source 0
+    target 1
+  ]
+  edge [
+    source 1
+    target 2
+  ]
+  edge [
+    source 2
+    target 3
+  ]
+  edge [
+    source 4
+    target 3
+  ]
+  edge [
+    source 0
+    target 5
+  ]
+  edge [
+    source 3
+    target 5
+  ]
+  edge [
+    source 5
+    target 6
+  ]
+]

--- a/test/assets/gml/quantized_attention.gml
+++ b/test/assets/gml/quantized_attention.gml
@@ -1,0 +1,71 @@
+Creator "Netron GML Example"
+Version "1.0"
+graph [
+  directed 1
+  node [
+    id 0
+    label "input"
+    op_type "Input"
+    shape "1x128x768"
+    dtype "float32"
+  ]
+  node [
+    id 1
+    label "layernorm1"
+    op_type "LayerNormalization"
+    epsilon 0.000001
+  ]
+  node [
+    id 2
+    label "self_attention"
+    op_type "Attention"
+    num_heads 12
+    head_dim 64
+  ]
+  node [
+    id 3
+    label "quant1"
+    op_type "QuantizeLinear"
+    scale 0.0078125
+    zero_point 128
+  ]
+  node [
+    id 4
+    label "dequant1"
+    op_type "DequantizeLinear"
+  ]
+  node [
+    id 5
+    label "layernorm2"
+    op_type "LayerNormalization"
+  ]
+  node [
+    id 6
+    label "output"
+    op_type "Output"
+  ]
+  edge [
+    source 0
+    target 1
+  ]
+  edge [
+    source 1
+    target 2
+  ]
+  edge [
+    source 2
+    target 3
+  ]
+  edge [
+    source 3
+    target 4
+  ]
+  edge [
+    source 4
+    target 5
+  ]
+  edge [
+    source 5
+    target 6
+  ]
+]

--- a/test/assets/gml/simple_cnn.gml
+++ b/test/assets/gml/simple_cnn.gml
@@ -1,0 +1,92 @@
+Creator "Netron GML Example"
+Version "1.0"
+graph [
+  directed 1
+  node [
+    id 0
+    label "input"
+    op_type "Input"
+    shape "1x3x224x224"
+    dtype "float32"
+  ]
+  node [
+    id 1
+    label "conv1"
+    op_type "Conv"
+    kernel_shape "3x3"
+    strides "1x1"
+    pads "1x1x1x1"
+    out_channels 64
+  ]
+  node [
+    id 2
+    label "bn1"
+    op_type "BatchNormalization"
+    epsilon 0.00001
+  ]
+  node [
+    id 3
+    label "relu1"
+    op_type "Relu"
+  ]
+  node [
+    id 4
+    label "pool1"
+    op_type "MaxPool"
+    kernel_shape "2x2"
+    strides "2x2"
+  ]
+  node [
+    id 5
+    label "flatten"
+    op_type "Flatten"
+  ]
+  node [
+    id 6
+    label "fc1"
+    op_type "Gemm"
+    out_features 10
+  ]
+  node [
+    id 7
+    label "softmax"
+    op_type "Softmax"
+  ]
+  node [
+    id 8
+    label "output"
+    op_type "Output"
+  ]
+  edge [
+    source 0
+    target 1
+  ]
+  edge [
+    source 1
+    target 2
+  ]
+  edge [
+    source 2
+    target 3
+  ]
+  edge [
+    source 3
+    target 4
+  ]
+  edge [
+    source 4
+    target 5
+  ]
+  edge [
+    source 5
+    target 6
+  ]
+  edge [
+    source 6
+    target 7
+  ]
+  edge [
+    source 7
+    target 8
+  ]
+]

--- a/test/models.json
+++ b/test/models.json
@@ -2344,6 +2344,27 @@
     "link":     "https://github.com/lutzroeder/netron/issues/1209"
   },
   {
+    "type":     "gml",
+    "target":   "simple_cnn.gml",
+    "source":   "https://github.com/user-attachments/files/REPLACE_ME/simple_cnn.gml.zip[simple_cnn.gml]",
+    "format":   "GML",
+    "assert":   "model.modules[0].nodes[6].type.name == 'Gemm'"
+  },
+  {
+    "type":     "gml",
+    "target":   "grouped_residual_block.gml",
+    "source":   "https://github.com/user-attachments/files/REPLACE_ME/grouped_residual_block.gml.zip[grouped_residual_block.gml]",
+    "format":   "GML",
+    "assert":   "model.modules[0].nodes[1].group == 'ResidualBlock'"
+  },
+  {
+    "type":     "gml",
+    "target":   "quantized_attention.gml",
+    "source":   "https://github.com/user-attachments/files/REPLACE_ME/quantized_attention.gml.zip[quantized_attention.gml]",
+    "format":   "GML",
+    "assert":   "model.modules[0].nodes[2].type.name == 'Attention'"
+  },
+  {
     "type":     "hailo",
     "target":   "fcn_hailo_pp_v2.har",
     "source":   "https://github.com/lutzroeder/netron/files/13482814/fcn_hailo_pp_v2.har.zip[fcn_hailo_pp_v2.har]",


### PR DESCRIPTION
GML (Graph Modelling Language) is a plain-text, S-expression-like format for describing graphs (nodes, edges, and nested clusters), commonly used by graph tools such as Gephi, yEd, and igraph. See https://en.wikipedia.org/wiki/Graph_Modelling_Language for the spec. Sample .gml files used to validate this support are checked into test/assets/gml/ (simple_cnn.gml, grouped_residual_block.gml, quantized_attention.gml).

- source/gml.js: new parser/model factory that reads `graph [ ... ]` blocks, including nested `node`, `edge`, and cluster subgraphs, and builds a Netron graph from them.
- source/view.js: register the '.gml' extension with a signature match on the leading `graph [` block, and label graph clusters with their name (derived from the cluster path) instead of leaving them unlabeled.
- source/grapher.js / source/grapher.css: render an optional label on cluster rectangles, with matching light/dark theme styling.
- source/base.js: add 'gml' (and 'dot') to the list of recognized archive/text source extensions.
- test/models.json and test/assets/gml/*.gml: add sample models and test entries exercising the new format.