### PR TITLE
Reduce read amplification when opening large models

### DIFF
--- a/source/browser.js
+++ b/source/browser.js
@@ -803,9 +803,9 @@ browser.FileStream = class {
         }
         if (!this._buffer || this._position < this._offset || this._position + length > this._offset + this._buffer.length) {
             this._offset = this._start + this._position;
-            const length = Math.min(0x10000000, this._start + this._length - this._offset);
-            if (!this._buffer || length !== this._buffer.length) {
-                this._buffer = new Uint8Array(length);
+            const size = Math.min(Math.max(length, 0x10000), this._start + this._length - this._offset);
+            if (!this._buffer || size !== this._buffer.length) {
+                this._buffer = new Uint8Array(size);
             }
             this._read(this._buffer, this._offset);
         }

--- a/source/node.js
+++ b/source/node.js
@@ -76,9 +76,9 @@ node.FileStream = class {
         }
         if (!this._buffer || this._position < this._offset || this._position + length > this._offset + this._buffer.length) {
             this._offset = this._position;
-            const length = Math.min(0x10000000, this._length - this._offset);
-            if (!this._buffer || length !== this._buffer.length) {
-                this._buffer = new Uint8Array(length);
+            const size = Math.min(Math.max(length, 0x10000), this._length - this._offset);
+            if (!this._buffer || size !== this._buffer.length) {
+                this._buffer = new Uint8Array(size);
             }
             this._read(this._buffer, this._offset);
         }

--- a/source/protobuf.js
+++ b/source/protobuf.js
@@ -635,7 +635,7 @@ protobuf.StreamReader = class extends protobuf.BinaryReader {
         if (!this._buffer || this._position < this._offset || this._position + length > this._offset + this._buffer.length) {
             this._offset = this._position;
             this._stream.seek(this._offset);
-            const size = Math.min(0x10000000, this._length - this._offset);
+            const size = Math.min(Math.max(length, 0x10000), this._length - this._offset);
             this._buffer = this._stream.read(size);
             this._view = new DataView(this._buffer.buffer, this._buffer.byteOffset, this._buffer.byteLength);
         }

--- a/source/python.js
+++ b/source/python.js
@@ -22757,7 +22757,7 @@ python.StreamReader = class {
         if (!this._buffer || this._position < this._offset || this._position + length > this._offset + this._buffer.length) {
             this._offset = this._position;
             this._stream.seek(this._offset);
-            const size = Math.max(length, Math.min(0x10000000, this._length - this._offset));
+            const size = Math.min(Math.max(length, 0x10000), this._length - this._offset);
             this._buffer = this._stream.read(size);
             this._view = new DataView(this._buffer.buffer, this._buffer.byteOffset, this._buffer.byteLength);
         }

--- a/source/zip.js
+++ b/source/zip.js
@@ -646,8 +646,14 @@ zip.InflaterStream = class {
     }
 
     _inflate(position, length) {
-        const size = Number.isInteger(position) && Number.isInteger(length) ? position + length : undefined;
+        let size = Number.isInteger(position) && Number.isInteger(length) ? position + length : undefined;
         if (this._buffer === undefined || (size !== undefined && this._buffer.length < size)) {
+            // Inflating restarts from the beginning of the entry, so grow the target
+            // geometrically. Otherwise a sequential scan that advances in small steps
+            // re-inflates the whole entry on every step.
+            if (size !== undefined && this._buffer !== undefined) {
+                size = Math.max(size, this._buffer.length * 2);
+            }
             const position = this._stream.position;
             this._stream.seek(this._offset);
             const buffer = this._stream.peek();


### PR DESCRIPTION
Fixes the read amplification described in #1596.

`FileStream._fill` and the two stream-backed readers always filled a fixed 256MB window on a
cache miss, regardless of how many bytes were requested. A 14-byte signature peek read 256MB
from disk, and archive formats whose entries are scattered across the file re-filled the
window once per entry.

This sizes the window to the request instead, with a 64KB minimum, in
`node.FileStream._fill`, `browser.FileStream._fill`, `protobuf.StreamReader._fill` and
`python.StreamReader._fill`.

### Results

Models with an identical 16-node graph and ~1GB of weights, so the difference is purely
data-path cost:

| 1GB model | open (before -> after) | disk read | RSS |
|---|---|---|---|
| `.pt2` | 1.83s -> **0.13s** | 4.25x -> 1.00x | 609 -> 76MB |
| `.npz` | 2.80s -> **0.10s** | 2.25x -> 0.00x | 1415 -> 71MB |
| `.pt` (state_dict) | 0.64s -> **0.12s** | 2.25x -> 1.00x | 613 -> 74MB |
| `.pt` (torchscript) | 0.70s -> **0.14s** | 2.25x -> 1.00x | 617 -> 80MB |
| `.safetensors` | 0.19s -> **0.01s** | 1.25x -> 1.00x | 321 -> 54MB |
| `.gguf` | 0.19s -> **0.01s** | 1.25x -> 1.00x | 323 -> 55MB |
| `.onnx` | 2.07s -> 1.81s | 2.56x -> 1.25x | unchanged |

### Verification

- `node package.js validate` passes (lint, `tag:validation`, desktop and browser Playwright
  tests).
- **Format coverage.** `test/models.js` additionally passes for one model of each of the 71
  types in `models.json`.
- **Model output is unchanged.** For 12 models (the 7 above, small controls, and
  `.tar`/`.tar.gz`/gzip-wrapped variants) a fingerprint over the graph structure plus a
  checksum of every initializer's bytes is identical before and after the change.
- **Differential test of the stream classes.** The pre-patch and post-patch classes were
  driven side by side with the same randomized sequence of `seek`/`skip`/`read`/`peek`
  (deterministic seed), asserting they agree with each other and with the underlying bytes:
  `node.FileStream` 20,060 read/peek ops plus `stream()` sub-views, `browser.FileStream`
  29,737 read/peek ops, all byte-identical. Happy to contribute this as a test if there is a
  place for it.
- No regression on small files (1MB `.pt2` 0.15s -> 0.12s, 1MB `.onnx` 0.05s -> 0.05s).
- The window size was swept from 16KB to 16MB; 16KB-4MB is flat and above 4MB the
  amplification returns, so 64KB is used as the minimum.

The timings are from the Node/desktop path. `browser.FileStream` carries the same change and
is covered by the differential test and the browser Playwright test, but I have no browser
timings for it.
