### PR TITLE
Add node neighborhood highlighting

### DIFF
--- a/source/grapher.css
+++ b/source/grapher.css
@@ -64,13 +64,19 @@
 
 #arrowhead { fill: #000; }
 #arrowhead-hover { fill: rgba(220, 0, 0, 0.9); }
+#arrowhead-input-highlight { fill: #008a3b; }
+#arrowhead-output-highlight { fill: #d32f2f; }
 #arrowhead-select { fill: rgba(220, 0, 0, 0.9); }
 
 .edge-paths { pointer-events: none; }
 .edge-path { stroke: #000; stroke-width: 1px; fill: none; marker-end: url("#arrowhead"); }
 .edge-paths-hit-test { pointer-events: stroke; stroke-width: 0.5em; fill: none; stroke: #000; stroke-opacity: 0.001; }
 
-.select > .node.node-border { stroke: rgba(220, 0, 0, 0.9); stroke-width: 2px; }
+.input-highlight > .node.node-border { stroke: #008a3b; stroke-width: 2px; }
+.input-highlight.edge-path { stroke: #008a3b; stroke-width: 1px; marker-end: url("#arrowhead-input-highlight"); }
+.output-highlight > .node.node-border { stroke: #d32f2f; stroke-width: 2px; }
+.output-highlight.edge-path { stroke: #d32f2f; stroke-width: 1px; marker-end: url("#arrowhead-output-highlight"); }
+.select > .node.node-border { stroke: #2563eb; stroke-width: 3px; }
 .select.edge-path { stroke: rgba(220, 0, 0, 0.9); stroke-width: 1px; marker-end: url("#arrowhead-select"); }
 .select.node-argument > rect { fill: transparent; stroke: rgba(220, 0, 0, 0.9); }
 
@@ -83,6 +89,8 @@
 
 .node-block > .node-block-background { fill: #fff; stroke: none; stroke-width: 0; }
 .node-block .edge-path { stroke: #000; stroke-width: 1px; fill: none; }
+.node-block .input-highlight.edge-path { stroke: #008a3b; marker-end: url("#arrowhead-input-highlight"); }
+.node-block .output-highlight.edge-path { stroke: #d32f2f; marker-end: url("#arrowhead-output-highlight"); }
 .node-block .select.edge-path { stroke: rgba(220, 0, 0, 0.9); marker-end: url("#arrowhead-select"); }
 
 @keyframes pulse { from { stroke-dashoffset: 100px; } to { stroke-dashoffset: 0; } }
@@ -94,11 +102,17 @@
     .node path { stroke: #242424; }
     .node line { stroke: #242424; }
 
-    .select > .node.node-border { stroke: rgba(192, 0, 0, 0.8); }
+    .input-highlight > .node.node-border { stroke: #4ade80; }
+    .input-highlight.edge-path { stroke: #4ade80; }
+    .output-highlight > .node.node-border { stroke: #f87171; }
+    .output-highlight.edge-path { stroke: #f87171; }
+    .select > .node.node-border { stroke: #60a5fa; }
     .select.edge-path { stroke: rgba(192, 0, 0, 0.8); }
     .select.node-argument > rect { fill: transparent; stroke: rgba(192, 0, 0, 0.8); }
     #arrowhead { fill: #888; }
     #arrowhead-hover { fill: rgba(192, 0, 0, 0.8); }
+    #arrowhead-input-highlight { fill: #4ade80; }
+    #arrowhead-output-highlight { fill: #f87171; }
     #arrowhead-select { fill: rgba(192, 0, 0, 0.8); }
 
     .edge-label { fill: #b2b2b2; }
@@ -151,6 +165,8 @@
 
     .node-block > .node-block-background { fill: #404040; stroke: none; }
     .node-block .edge-path { stroke: #888; }
+    .node-block .input-highlight.edge-path { stroke: #4ade80; marker-end: url("#arrowhead-input-highlight"); }
+    .node-block .output-highlight.edge-path { stroke: #f87171; marker-end: url("#arrowhead-output-highlight"); }
     .node-block .select.edge-path { stroke: rgba(192, 0, 0, 0.8); marker-end: url("#arrowhead-select"); }
 
     .edge-path-tunnel { stroke: #888; opacity: 0.5; }

--- a/source/grapher.js
+++ b/source/grapher.js
@@ -161,6 +161,8 @@ grapher.Graph = class {
             }
         });
         edgePathGroupDefs.appendChild(marker("arrowhead"));
+        edgePathGroupDefs.appendChild(marker("arrowhead-input-highlight"));
+        edgePathGroupDefs.appendChild(marker("arrowhead-output-highlight"));
         edgePathGroupDefs.appendChild(marker("arrowhead-select"));
         edgePathGroupDefs.appendChild(marker("arrowhead-hover"));
         for (const nodeId of this.nodes.keys()) {

--- a/source/view.js
+++ b/source/view.js
@@ -1848,6 +1848,7 @@ view.Graph = class extends grapher.Graph {
         this._tensors = new Map();
         this._table = new Map();
         this._selection = new Set();
+        this._neighborhood = [];
         this.blocks = new Set();
         this._zoom = 1;
         this._listeners = {};
@@ -2361,6 +2362,12 @@ view.Graph = class extends grapher.Graph {
     }
 
     clearSelection() {
+        for (const [item, className] of this._neighborhood) {
+            if (item.element) {
+                item.element.classList.remove(className);
+            }
+        }
+        this._neighborhood = [];
         if (this._selection.size > 0) {
             for (const element of this._selection) {
                 element.deselect();
@@ -2393,11 +2400,35 @@ view.Graph = class extends grapher.Graph {
                     this._selection.add(element);
                 }
             }
+            if (this._selection.size === 1) {
+                const [element] = this._selection;
+                if (element instanceof grapher.Node) {
+                    this._highlightNeighborhood(element);
+                }
+            }
             this.emit('selectionchange', source);
             return array;
         }
         this.emit('selectionchange', source);
         return null;
+    }
+
+    _highlightNeighborhood(node) {
+        const highlight = (item, className) => {
+            if (item.element) {
+                item.element.classList.add(className);
+                this._neighborhood.push([item, className]);
+            }
+        };
+        for (const { label: edge } of this.edges.values()) {
+            if (edge.to === node && edge.from !== node) {
+                highlight(edge.from, 'input-highlight');
+                highlight(edge, 'input-highlight');
+            } else if (edge.from === node && edge.to !== node) {
+                highlight(edge.to, 'output-highlight');
+                highlight(edge, 'output-highlight');
+            }
+        }
     }
 
     activate(value, source) {

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -67,3 +67,55 @@ playwright.test('browser', async ({ page }) => {
     const first = parseFloat(match[0]);
     playwright.expect(first).toBe(0.1353299617767334);
 });
+
+playwright.test('node neighborhood highlighting', async ({ page }) => {
+
+    const self = url.fileURLToPath(import.meta.url);
+    const dir = path.dirname(self);
+    const file = path.resolve(dir, 'neighborhood.dot');
+    playwright.expect(fs.existsSync(file)).toBeTruthy();
+    await page.emulateMedia({ colorScheme: 'light' });
+
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForSelector('body.welcome', { timeout: 25000 });
+
+    const consent = page.locator('#message-button');
+    if (await consent.isVisible()) {
+        await consent.click();
+    }
+
+    const fileChooserPromise = page.waitForEvent('filechooser');
+    await page.locator('.open-file-button, button:has-text("Open Model")').click();
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(file);
+    await page.waitForSelector('body.default', { timeout: 10000 });
+
+    await page.locator('#node-name-selected .node-item-type').click();
+
+    const inputEdges = page.locator('.edge-path.input-highlight');
+    const outputEdges = page.locator('.edge-path.output-highlight');
+    await playwright.expect(page.locator('#node-name-selected')).toHaveClass(/\bselect\b/);
+    await playwright.expect(page.locator('#node-name-input')).toHaveClass(/\binput-highlight\b/);
+    await playwright.expect(page.locator('#node-name-output')).toHaveClass(/\boutput-highlight\b/);
+    await playwright.expect(inputEdges).toHaveCount(1);
+    await playwright.expect(outputEdges).toHaveCount(1);
+    await playwright.expect(page.locator('#node-name-input > .node-border')).toHaveCSS('stroke', 'rgb(0, 138, 59)');
+    await playwright.expect(page.locator('#node-name-selected > .node-border')).toHaveCSS('stroke', 'rgb(37, 99, 235)');
+    await playwright.expect(page.locator('#node-name-output > .node-border')).toHaveCSS('stroke', 'rgb(211, 47, 47)');
+    await playwright.expect(inputEdges).toHaveCSS('marker-end', /arrowhead-input-highlight/);
+    await playwright.expect(outputEdges).toHaveCSS('marker-end', /arrowhead-output-highlight/);
+
+    const canvas = page.locator('#canvas');
+    const style = await canvas.getAttribute('style');
+    await page.locator('#zoom-in-button').click();
+    await playwright.expect.poll(async () => await canvas.getAttribute('style')).not.toBe(style);
+    await playwright.expect(inputEdges).toHaveCount(1);
+    await playwright.expect(outputEdges).toHaveCount(1);
+
+    await page.locator('#node-name-output .node-item-type').click();
+    await playwright.expect(page.locator('#node-name-input')).not.toHaveClass(/\binput-highlight\b/);
+    await playwright.expect(page.locator('#node-name-selected')).toHaveClass(/\binput-highlight\b/);
+    await playwright.expect(page.locator('#node-name-output > .node-border')).toHaveCSS('stroke', 'rgb(37, 99, 235)');
+    await playwright.expect(outputEdges).toHaveCount(0);
+});

--- a/test/neighborhood.dot
+++ b/test/neighborhood.dot
@@ -1,0 +1,3 @@
+digraph neighborhood {
+    input -> selected -> output;
+}


### PR DESCRIPTION
## Summary

- highlight direct input nodes and edges in green
- highlight the selected node with a thicker blue border
- highlight direct output nodes and edges in red
- preserve highlighting across zoom and clear it when selection changes

## Motivation

Large model graphs are difficult to trace when selection only identifies the current node. Distinct colors for immediate incoming and outgoing relationships make local data flow visible without recursively coloring the graph.

## Implementation

`view.Graph` applies directional classes to directly connected rendered nodes and edges when exactly one graph node is selected. Dedicated SVG markers preserve arrow direction, and light/dark theme styles distinguish input, selection, and output states. The implementation reuses the existing selection lifecycle and does not add a graph index or change version and packaging behavior.

## Validation

- `git diff --check`
- full ESLint 10.9.1 run
- JavaScript syntax checks
- focused Playwright coverage added in `test/browser.spec.js`
- browser verification of colors, directional markers, zoom persistence, and selection cleanup

This single-commit PR is rebuilt from current `main` and replaces #1600, whose base history was rewritten by an upstream force-push.